### PR TITLE
fix: avoid using `--filter` for running benchmark

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "build": "bun run --filter '@filtron/*' build",
     "test": "bun test",
     "lint": "oxlint --type-aware && oxfmt",
-    "bench": "bun run --filter '@filtron/core' bench"
+    "bench": "cd packages/core && bun run bench"
   },
   "devDependencies": {
     "oxfmt": "0.13.0",


### PR DESCRIPTION
Bun truncates output when using `--filter` since its meant to support multiple outputs from multiple commands.