### PR TITLE
feat: add renovatebot dependency management

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,39 +1,43 @@
 {
-	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"baseBranchPatterns": ["main"],
-	"timezone": "Europe/Lisbon",
-	"schedule": ["before 9pm on sunday"],
-	"extends": [":dependencyDashboard", ":disableRateLimiting", ":semanticCommits"],
-	"rangeStrategy": "pin",
-	"enabledManagers": ["github-actions", "custom.regex", "npm"],
-	"commitMessageAction": "",
-	"commitMessageTopic": "{{depName}}",
-	"commitMessageExtra": "{{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}{{/if}}",
-	"packageRules": [
-		{
-			"matchManagers": ["github-actions"],
-			"commitMessageTopic": "{{depName}}"
-		},
-		{
-			"commitMessageTopic": "actionlint",
-			"matchPackageNames": ["/actionlint/"]
-		}
-	],
-	"customManagers": [
-		{
-			"customType": "regex",
-			"managerFilePatterns": ["/^\\.github/workflows/[^/]+\\.yml$/"],
-			"matchStrings": [
-				"version: \"(?<currentValue>.*?)\"\\s+run: curl -Ls( -o \\w+)? \"https://github.com/(?<depName>.*?)/releases/download.*",
-				"https://github\\.com/(?<depName>.*?)/archive/refs/tags/v(?<currentValue>.*?)\\.tar\\.gz"
-			],
-			"datasourceTemplate": "github-releases",
-			"extractVersionTemplate": "^v(?<version>.*)$"
-		}
-	],
-	"rebaseWhen": "never",
-	"labels": ["Dependencies"],
-	"prBodyTemplate": "{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{controls}}}{{{footer}}}",
-	"prHeader": "",
-	"prFooter": ""
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "baseBranchPatterns": ["main"],
+  "timezone": "Europe/Lisbon",
+  "schedule": ["before 9pm on sunday"],
+  "extends": [
+    ":dependencyDashboard",
+    ":disableRateLimiting",
+    ":semanticCommits"
+  ],
+  "rangeStrategy": "pin",
+  "enabledManagers": ["github-actions", "custom.regex", "npm"],
+  "commitMessageAction": "",
+  "commitMessageTopic": "{{depName}}",
+  "commitMessageExtra": "{{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}{{/if}}",
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "commitMessageTopic": "{{depName}}"
+    },
+    {
+      "commitMessageTopic": "actionlint",
+      "matchPackageNames": ["/actionlint/"]
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/[^/]+\\.yml$/"],
+      "matchStrings": [
+        "version: \"(?<currentValue>.*?)\"\\s+run: curl -Ls( -o \\w+)? \"https://github.com/(?<depName>.*?)/releases/download.*",
+        "https://github\\.com/(?<depName>.*?)/archive/refs/tags/v(?<currentValue>.*?)\\.tar\\.gz"
+      ],
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    }
+  ],
+  "rebaseWhen": "never",
+  "labels": ["Dependencies"],
+  "prBodyTemplate": "{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{controls}}}{{{footer}}}",
+  "prHeader": "",
+  "prFooter": ""
 }


### PR DESCRIPTION
This config has a custom rule I tend to use when downloading binaries that doesn't get wrapped in a custom github action or a package. CI jobs will be added shortly.