### PR TITLE
chore(docs): reduce README length

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,17 +185,6 @@ if (result.success) {
 
 See the [@filtron/sql README](./packages/sql/README.md) for full documentation.
 
-## Performance
-
-```
-Parse Time:       ~50μs per query
-Throughput:       18,755 parses/sec
-Startup:          <1ms with pre-compiled grammar
-Memory:           Efficient GC, minimal allocation
-```
-
-Run benchmarks: `bun run bench`
-
 ## Contributing
 
 See the [Contributing Guide](./CONTRIBUTING.md) for development setup and workflow guidelines.
@@ -207,9 +196,3 @@ The Filtron query language syntax was strongly inspired by [dumbql](https://gith
 ## License
 
 MIT - See [LICENSE](./LICENSE)
-
-## Links
-
-- **GitHub**: https://github.com/jbergstroem/filtron
-- **npm**: https://www.npmjs.com/package/@filtron/core
-- **Issues**: https://github.com/jbergstroem/filtron/issues

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -7,10 +7,9 @@ Fast, type-safe query language parser for filtering data in real-time APIs. Buil
 
 ## Features
 
-- **Fast**: ~50μs parse time, 18K+ parses/sec
+- **Fast**: ~50μs parse time, 18K+ parses/sec (benchmarked on M2 Max)
 - **Small**: 15 KB minified, 56 KB installed
 - **Type-safe**: Full TypeScript support with discriminated union AST
-- **Snack-sized dependencies**: Only `ohm-js` runtime required
 
 ## Installation
 
@@ -189,13 +188,3 @@ Run benchmarks: `bun run bench`
 ## Inspiration
 
 The Filtron query language syntax was strongly inspired by [dumbql](https://github.com/tomakado/dumbql).
-
-## License
-
-MIT - See [LICENSE](./LICENSE)
-
-## Links
-
-- **GitHub**: https://github.com/jbergstroem/filtron
-- **npm**: https://www.npmjs.com/package/@filtron/core
-- **Issues**: https://github.com/jbergstroem/filtron/issues


### PR DESCRIPTION
Part of the auto-generated docs became too lengthy to ingest over one coffee. Remove verbose things such as extra examples.