### PR TITLE
chore: core build should run all repos, not just sql

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     }
   },
   "scripts": {
-    "build": "bun run --filter '@filtron/core' build && bun run --filter '@filtron/sql' build",
+    "build": "bun run --filter '@filtron/core' build && bun run --filter '!@filtron/core' build",
     "test": "bun test",
     "lint": "oxlint --type-aware && oxfmt",
     "bench": "cd packages/core && bun run bench"


### PR DESCRIPTION
When we add more packages (or build examples), make the core `package.json` not require maintenance.