### PR TITLE
chore: enable sourcemaps in benchmarks

### DIFF
--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -7,8 +7,8 @@
   "type": "module",
   "scripts": {
     "bench": "bun run bench:core && bun run bench:sql",
-    "bench:core": "node core.bench.ts",
-    "bench:sql": "node sql.bench.ts"
+    "bench:core": "node --enable-source-maps core.bench.ts",
+    "bench:sql": "node --enable-source-maps sql.bench.ts"
   },
   "dependencies": {
     "@codspeed/tinybench-plugin": "5.0.1",


### PR DESCRIPTION
Since CodSpeed provides flamegraphs, we can make it easier to follow by passing sourcemaps to the runtime.

