### PR TITLE
fix: emit javascript sourcemap when building distfiles

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,7 +46,7 @@
   ],
   "scripts": {
     "bench": "bun build && bun --expose-gc run benchmark.ts",
-    "build": "bun run build:grammar && bun build --minify --splitting --outdir=dist --external ohm-js index.ts && tsc --emitDeclarationOnly --declaration --declarationMap --outDir dist --skipLibCheck",
+    "build": "bun run build:grammar && bun build --minify --splitting --sourcemap=linked --outdir=dist --external ohm-js index.ts && tsc --emitDeclarationOnly --declaration --declarationMap --outDir dist --skipLibCheck",
     "build:grammar": "bun run ohm generateBundles --withTypes --esm src/grammar.ohm",
     "prepublishOnly": "bun run build && bun test",
     "test": "bun test"

--- a/packages/sql/package.json
+++ b/packages/sql/package.json
@@ -44,7 +44,7 @@
   ],
   "scripts": {
     "bench": "bun --expose-gc run benchmark.ts",
-    "build": "bun build --minify --splitting --outdir=dist --external @filtron/core index.ts && tsc -p tsconfig.build.json",
+    "build": "bun build --minify --splitting --sourcemap=linked --outdir=dist --external @filtron/core index.ts && tsc -p tsconfig.build.json",
     "lint": "oxlint --type-aware && oxfmt",
     "prepublishOnly": "bun run build && bun test",
     "test": "bun test"


### PR DESCRIPTION
I noticed that javascript sourcemaps were missing while triaging CodSpeed flamegraphs (#55). This change fixes it.