### PR TITLE
chore: refactor core tests

### DIFF
--- a/packages/core/src/lexer.test.ts
+++ b/packages/core/src/lexer.test.ts
@@ -51,15 +51,7 @@ describe("Lexer", () => {
 
 	describe("Operators", () => {
 		test("comparison operators", () => {
-			expect(tokenTypes("= != > >= < <=")).toEqual([
-				"EQ",
-				"NEQ",
-				"GT",
-				"GTE",
-				"LT",
-				"LTE",
-				"EOF",
-			]);
+			expect(tokenTypes("= != > >= < <=")).toEqual(["EQ", "NEQ", "GT", "GTE", "LT", "LTE", "EOF"]);
 		});
 
 		test("like operator", () => {
@@ -252,11 +244,7 @@ describe("Lexer", () => {
 		});
 
 		test("multiple comments", () => {
-			expect(tokenTypes("a // comment 1\n// comment 2\nb")).toEqual([
-				"IDENT",
-				"IDENT",
-				"EOF",
-			]);
+			expect(tokenTypes("a // comment 1\n// comment 2\nb")).toEqual(["IDENT", "IDENT", "EOF"]);
 		});
 	});
 

--- a/packages/core/src/parser.test.ts
+++ b/packages/core/src/parser.test.ts
@@ -143,15 +143,15 @@ describe("Parser API", () => {
 
 		test("handles all expression types", () => {
 			const queries = [
-				"field",                                    // booleanField
-				"field?",                                   // exists
-				"field = value",                            // comparison
-				'field : ["a", "b"]',                       // oneOf
-				'field !: ["a", "b"]',                      // notOneOf
-				"field = 1..10",                            // range
-				"a AND b",                                  // and
-				"a OR b",                                   // or
-				"NOT a",                                    // not
+				"field", // booleanField
+				"field?", // exists
+				"field = value", // comparison
+				'field : ["a", "b"]', // oneOf
+				'field !: ["a", "b"]', // notOneOf
+				"field = 1..10", // range
+				"a AND b", // and
+				"a OR b", // or
+				"NOT a", // not
 			];
 
 			for (const query of queries) {

--- a/packages/core/src/rd-parser.test.ts
+++ b/packages/core/src/rd-parser.test.ts
@@ -1,5 +1,4 @@
 import { describe, test, expect } from "bun:test";
-import { parseQuery, ParseError } from "./rd-parser";
 import type {
 	ComparisonExpression,
 	OrExpression,
@@ -11,6 +10,7 @@ import type {
 	NotOneOfExpression,
 	RangeExpression,
 } from "./types";
+import { parseQuery, ParseError } from "./rd-parser";
 
 describe("Recursive Descent Parser", () => {
 	describe("Field Expressions", () => {
@@ -323,7 +323,9 @@ describe("Recursive Descent Parser", () => {
 		});
 
 		test("admin dashboard access", () => {
-			const ast = parseQuery('(role : ["admin", "superadmin"]) AND (NOT suspended) AND last_login?');
+			const ast = parseQuery(
+				'(role : ["admin", "superadmin"]) AND (NOT suspended) AND last_login?',
+			);
 			expect(ast.type).toBe("and");
 		});
 


### PR DESCRIPTION
Split out tests from `parser.test.ts` to either lexer or parser, keeping a smaller high-level test suite for `parser.ts`.