### PR TITLE
feat: split out packages into codecov components

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -18,7 +18,7 @@ component_management:
       paths:
         - ^packages/sql/.*
     - component_id: js
-      name: Javascript Filter
+      name: JavaScript Filter
       paths:
         - ^packages/js/.*
     - component_id: elysia-example


### PR DESCRIPTION
This allows us to set up different rulesets per component

Closes: https://github.com/jbergstroem/filtron/issues/65