### PR TITLE
chore(docs): badges display package size, coverage and version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Fast, type-safe query language parser for filtering data in real-time APIs.
 - **[@filtron/js](./packages/js)** - In-memory JavaScript array filtering
 - **[@filtron/benchmark](./packages/benchmark)** - Benchmarks for CI (private package)
 
-[![npm version](https://img.shields.io/npm/v/@filtron/core.svg)](https://www.npmjs.com/package/@filtron/core)
+[![CodSpeed](https://img.shields.io/endpoint?url=https://codspeed.io/badge.json)](https://codspeed.io/jbergstroem/filtron?utm_source=badge)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
 
 ## Features

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,8 +2,9 @@
 
 Fast, type-safe query language parser for filtering data in real-time APIs.
 
-[![npm version](https://img.shields.io/npm/v/@filtron/core.svg)](https://www.npmjs.com/package/@filtron/core)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
+![npm version](https://img.shields.io/npm/v/@filtron/core.svg)
+![npm bundle size](https://img.shields.io/bundlephobia/min/%40filtron%core)
+![codecov](https://codecov.io/gh/jbergstroem/filtron/graph/badge.svg?token=FXIWJKJ9RI&component=core)
 
 ## Features
 

--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -2,6 +2,10 @@
 
 In-memory JavaScript array filtering using [Filtron](https://github.com/jbergstroem/filtron) AST.
 
+![npm version](https://img.shields.io/npm/v/@filtron/js.svg)
+![npm bundle size](https://img.shields.io/bundlephobia/min/%40filtron%js)
+![codecov](https://codecov.io/gh/jbergstroem/filtron/graph/badge.svg?token=FXIWJKJ9RI&component=js)
+
 ## Installation
 
 ```bash

--- a/packages/sql/README.md
+++ b/packages/sql/README.md
@@ -2,6 +2,10 @@
 
 SQL WHERE clause generator for [Filtron](https://github.com/jbergstroem/filtron) AST with parameterized queries.
 
+![npm version](https://img.shields.io/npm/v/@filtron/sql.svg)
+![npm bundle size](https://img.shields.io/bundlephobia/min/%40filtron%sql)
+![codecov](https://codecov.io/gh/jbergstroem/filtron/graph/badge.svg?token=FXIWJKJ9RI&component=sql)
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
Move badges to each part of the repository instead of the global readme.

Closes: https://github.com/jbergstroem/filtron/issues/66