### PR TITLE
fix: escape slash in badge url

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -3,7 +3,7 @@
 Fast, type-safe query language parser for filtering data in real-time APIs.
 
 ![npm version](https://img.shields.io/npm/v/@filtron/core.svg)
-![npm bundle size](https://img.shields.io/bundlephobia/min/%40filtron%core)
+![npm bundle size](https://img.shields.io/bundlephobia/min/%40filtron%2Fcore)
 ![codecov](https://codecov.io/gh/jbergstroem/filtron/graph/badge.svg?token=FXIWJKJ9RI&component=core)
 
 ## Features

--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -3,7 +3,7 @@
 In-memory JavaScript array filtering using [Filtron](https://github.com/jbergstroem/filtron) AST.
 
 ![npm version](https://img.shields.io/npm/v/@filtron/js.svg)
-![npm bundle size](https://img.shields.io/bundlephobia/min/%40filtron%js)
+![npm bundle size](https://img.shields.io/bundlephobia/min/%40filtron%2Fjs)
 ![codecov](https://codecov.io/gh/jbergstroem/filtron/graph/badge.svg?token=FXIWJKJ9RI&component=js)
 
 ## Installation

--- a/packages/sql/README.md
+++ b/packages/sql/README.md
@@ -3,7 +3,7 @@
 SQL WHERE clause generator for [Filtron](https://github.com/jbergstroem/filtron) AST with parameterized queries.
 
 ![npm version](https://img.shields.io/npm/v/@filtron/sql.svg)
-![npm bundle size](https://img.shields.io/bundlephobia/min/%40filtron%sql)
+![npm bundle size](https://img.shields.io/bundlephobia/min/%40filtron%2Fsql)
 ![codecov](https://codecov.io/gh/jbergstroem/filtron/graph/badge.svg?token=FXIWJKJ9RI&component=sql)
 
 ## Installation


### PR DESCRIPTION
Somehow the `2F` got lost in translation.