### PR TITLE
fix(renovate): don't pin node in ci

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,6 +25,11 @@
     {
       "matchDepTypes": ["engines", "peerDependencies"],
       "enabled": false
+    },
+    {
+      "matchFileNames": [".github/workflows/benchmarks.yml"],
+      "matchPackageNames": ["node"],
+      "enabled": false
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Renovate shouldn't be concerned about pinning nodejs in CI, we can stick with latest LTS instead of being explicit.

Closes: https://github.com/jbergstroem/filtron/issues/64