### PR TITLE
chore: pin gha versions to sha

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,8 @@
   "extends": [
     ":dependencyDashboard",
     ":disableRateLimiting",
-    ":semanticCommits"
+    ":semanticCommits",
+    "helpers:pinGitHubActionDigests"
   ],
   "rangeStrategy": "pin",
   "enabledManagers": ["github-actions", "custom.regex", "npm"],


### PR DESCRIPTION
This is part improving security with input from [zizmor](https://docs.zizmor.sh).

Refs: https://docs.renovatebot.com/modules/manager/github-actions/#digest-pinning-and-updating