### PR TITLE
chore(deps): update oxclint/oxfmt

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -4,10 +4,13 @@ about: Something's broken
 ---
 
 ## Problem
+
 <!-- What's broken? -->
 
 ## Expected
+
 <!-- What should happen? -->
 
 ## Steps
+
 <!-- How to reproduce? -->

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -4,7 +4,9 @@ about: Something new
 ---
 
 ## What
+
 <!-- What do you want? -->
 
 ## Why
+
 <!-- Why do you need it? -->

--- a/.github/matchers/actionlint.json
+++ b/.github/matchers/actionlint.json
@@ -1,17 +1,17 @@
 {
-  "problemMatcher": [
-    {
-      "owner": "actionlint",
-      "pattern": [
-        {
-          "regexp": "^(?:\\x1b\\[\\d+m)?(.+?)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*: (?:\\x1b\\[\\d+m)*(.+?)(?:\\x1b\\[\\d+m)* \\[(.+?)\\]$",
-          "file": 1,
-          "line": 2,
-          "column": 3,
-          "message": 4,
-          "code": 5
-        }
-      ]
-    }
-  ]
+	"problemMatcher": [
+		{
+			"owner": "actionlint",
+			"pattern": [
+				{
+					"regexp": "^(?:\\x1b\\[\\d+m)?(.+?)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*: (?:\\x1b\\[\\d+m)*(.+?)(?:\\x1b\\[\\d+m)* \\[(.+?)\\]$",
+					"file": 1,
+					"line": 2,
+					"column": 3,
+					"message": 4,
+					"code": 5
+				}
+			]
+		}
+	]
 }

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,11 @@
 ## What
+
 <!-- What changed? -->
 
 ## Why
+
 <!-- Why did it change? -->
 
 ## Notes
+
 <!-- Anything reviewers should know? -->

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,53 +1,53 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "baseBranchPatterns": ["main"],
-  "timezone": "Europe/Lisbon",
-  "schedule": ["before 9pm on sunday"],
-  "extends": [
-    ":dependencyDashboard",
-    ":disableRateLimiting",
-    ":semanticCommits",
-    "helpers:pinGitHubActionDigests"
-  ],
-  "rangeStrategy": "pin",
-  "enabledManagers": ["github-actions", "custom.regex", "npm"],
-  "commitMessageAction": "",
-  "commitMessageTopic": "{{depName}}",
-  "commitMessageExtra": "{{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}{{/if}}",
-  "packageRules": [
-    {
-      "matchManagers": ["github-actions"],
-      "commitMessageTopic": "{{depName}}"
-    },
-    {
-      "commitMessageTopic": "actionlint",
-      "matchPackageNames": ["/actionlint/"]
-    },
-    {
-      "matchDepTypes": ["engines", "peerDependencies"],
-      "enabled": false
-    },
-    {
-      "matchFileNames": [".github/workflows/benchmarks.yml"],
-      "matchPackageNames": ["node"],
-      "enabled": false
-    }
-  ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^\\.github/workflows/[^/]+\\.yml$/"],
-      "matchStrings": [
-        "version: \"(?<currentValue>.*?)\"\\s+run: curl -Ls( -o \\w+)? \"https://github.com/(?<depName>.*?)/releases/download.*",
-        "https://github\\.com/(?<depName>.*?)/archive/refs/tags/v(?<currentValue>.*?)\\.tar\\.gz"
-      ],
-      "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^v(?<version>.*)$"
-    }
-  ],
-  "rebaseWhen": "never",
-  "labels": ["Dependencies"],
-  "prBodyTemplate": "{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{controls}}}{{{footer}}}",
-  "prHeader": "",
-  "prFooter": ""
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"baseBranchPatterns": ["main"],
+	"timezone": "Europe/Lisbon",
+	"schedule": ["before 9pm on sunday"],
+	"extends": [
+		":dependencyDashboard",
+		":disableRateLimiting",
+		":semanticCommits",
+		"helpers:pinGitHubActionDigests"
+	],
+	"rangeStrategy": "pin",
+	"enabledManagers": ["github-actions", "custom.regex", "npm"],
+	"commitMessageAction": "",
+	"commitMessageTopic": "{{depName}}",
+	"commitMessageExtra": "{{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}{{/if}}",
+	"packageRules": [
+		{
+			"matchManagers": ["github-actions"],
+			"commitMessageTopic": "{{depName}}"
+		},
+		{
+			"commitMessageTopic": "actionlint",
+			"matchPackageNames": ["/actionlint/"]
+		},
+		{
+			"matchDepTypes": ["engines", "peerDependencies"],
+			"enabled": false
+		},
+		{
+			"matchFileNames": [".github/workflows/benchmarks.yml"],
+			"matchPackageNames": ["node"],
+			"enabled": false
+		}
+	],
+	"customManagers": [
+		{
+			"customType": "regex",
+			"managerFilePatterns": ["/^\\.github/workflows/[^/]+\\.yml$/"],
+			"matchStrings": [
+				"version: \"(?<currentValue>.*?)\"\\s+run: curl -Ls( -o \\w+)? \"https://github.com/(?<depName>.*?)/releases/download.*",
+				"https://github\\.com/(?<depName>.*?)/archive/refs/tags/v(?<currentValue>.*?)\\.tar\\.gz"
+			],
+			"datasourceTemplate": "github-releases",
+			"extractVersionTemplate": "^v(?<version>.*)$"
+		}
+	],
+	"rebaseWhen": "never",
+	"labels": ["Dependencies"],
+	"prBodyTemplate": "{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{controls}}}{{{footer}}}",
+	"prHeader": "",
+	"prFooter": ""
 }

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "./node_modules/oxfmt/configuration_schema.json",
-  "useTabs": true,
-  "indentWidth": 2,
-  "lineWidth": 120,
-  "experimentalSortImports": {
-      "newlinesBetween": false,
-      "partitionByNewline": false,
-      "partitionByComment": false,
-      "sortSideEffects": false,
-      "order": "asc",
-      "ignoreCase": true
-    },
-  "ignorePatterns": ["packages/core/src/grammar.ohm-bundle.*"]
+	"$schema": "./node_modules/oxfmt/configuration_schema.json",
+	"useTabs": true,
+	"indentWidth": 2,
+	"lineWidth": 120,
+	"experimentalSortImports": {
+		"newlinesBetween": false,
+		"partitionByNewline": false,
+		"partitionByComment": false,
+		"sortSideEffects": false,
+		"order": "asc",
+		"ignoreCase": true
+	},
+	"ignorePatterns": ["packages/core/src/grammar.ohm-bundle.*"]
 }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,17 +1,12 @@
 {
-  "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": [
-    "import",
-    "oxc",
-    "typescript",
-    "unicorn"
-  ],
-  "env": {
-    "builtin": true
-  },
-  "ignorePatterns": ["src/grammar.ohm-bundle.*"],
-  "rules": {
-    "typescript/no-floating-promises": "error",
-    "typescript/no-misused-promises": "error"
-  }
+	"$schema": "./node_modules/oxlint/configuration_schema.json",
+	"plugins": ["import", "oxc", "typescript", "unicorn"],
+	"env": {
+		"builtin": true
+	},
+	"ignorePatterns": ["src/grammar.ohm-bundle.*"],
+	"rules": {
+		"typescript/no-floating-promises": "error",
+		"typescript/no-misused-promises": "error"
+	}
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,24 +14,24 @@
 
 ## Key Files
 
-| Purpose | Path |
-|---------|------|
-| Lexer (tokenizer) | `packages/core/src/lexer.ts` |
+| Purpose                  | Path                             |
+| ------------------------ | -------------------------------- |
+| Lexer (tokenizer)        | `packages/core/src/lexer.ts`     |
 | Recursive descent parser | `packages/core/src/rd-parser.ts` |
-| Parser API | `packages/core/src/parser.ts` |
-| AST types | `packages/core/src/types.ts` |
-| JS filter | `packages/js/src/filter.ts` |
-| SQL generator | `packages/sql/src/converter.ts` |
-| Benchmarks | `packages/benchmark/*.bench.ts` |
+| Parser API               | `packages/core/src/parser.ts`    |
+| AST types                | `packages/core/src/types.ts`     |
+| JS filter                | `packages/js/src/filter.ts`      |
+| SQL generator            | `packages/sql/src/converter.ts`  |
+| Benchmarks               | `packages/benchmark/*.bench.ts`  |
 
 ## Commands
 
-| Task | Command |
-|------|---------|
-| Run tests | `bun test` |
-| Run benchmarks | `bun run bench` |
-| Lint/format | `bun run lint` |
-| Type check | `bun run typecheck` |
+| Task           | Command             |
+| -------------- | ------------------- |
+| Run tests      | `bun test`          |
+| Run benchmarks | `bun run bench`     |
+| Lint/format    | `bun run lint`      |
+| Type check     | `bun run typecheck` |
 
 ## Performance Requirements
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ bun run lint
 
 5. **Update documentation**
    - **README.md** - Quick start and overview
-   - **packages/*/README.md** - Package-specific documentation
+   - **packages/\*/README.md** - Package-specific documentation
    - **CONTRIBUTING.md** - Development guide
    - **AGENTS.md** - Agent collaboration guide
    - **JSDoc comments** - In-code documentation
@@ -135,7 +135,6 @@ bun run build --filter='@filtron/core'
 - [ ] Documentation updated (if API changed)
 - [ ] Benchmarks run (if performance-sensitive code changed)
 - [ ] Commit messages follow conventions
-
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -196,11 +196,11 @@ function handleAST(node: ASTNode) {
 
 Filtron uses a hand-written recursive descent parser optimized for speed:
 
-| Query Type | Parse Time    | Throughput       |
-| ---------- | ------------- | ---------------- |
-| Simple     | ~250-350ns    | 3-4M ops/sec     |
-| Medium     | ~600-1700ns   | 600K-1.6M ops/sec |
-| Complex    | ~1.5-3μs      | 350-700K ops/sec |
+| Query Type | Parse Time  | Throughput        |
+| ---------- | ----------- | ----------------- |
+| Simple     | ~250-350ns  | 3-4M ops/sec      |
+| Medium     | ~600-1700ns | 600K-1.6M ops/sec |
+| Complex    | ~1.5-3μs    | 350-700K ops/sec  |
 
 Run benchmarks: `bun run bench`
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,9 +5,9 @@
     "": {
       "name": "filtron",
       "devDependencies": {
-        "oxfmt": "0.16.0",
-        "oxlint": "1.31.0",
-        "oxlint-tsgolint": "0.8.3",
+        "oxfmt": "0.17.0",
+        "oxlint": "1.32.0",
+        "oxlint-tsgolint": "0.8.4",
       },
     },
     "examples/elysia-sqlite": {
@@ -90,7 +90,7 @@
     },
   },
   "catalog": {
-    "@types/bun": "1.3.3",
+    "@types/bun": "1.3.4",
     "mitata": "1.0.34",
     "typescript": "5.9.3",
   },
@@ -111,49 +111,49 @@
 
     "@filtron/sql": ["@filtron/sql@workspace:packages/sql"],
 
-    "@oxfmt/darwin-arm64": ["@oxfmt/darwin-arm64@0.16.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-I+Unj7wePcUTK7p/YKtgbm4yer6dw7dTlmCJa0UilFZyge5uD4rwCSfSDx3A+a6Z3A60/SqXMbNR2UyidWF4Cg=="],
+    "@oxfmt/darwin-arm64": ["@oxfmt/darwin-arm64@0.17.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-OMv0tOb+xiwSZKjYbM6TwMSP5QwFJlBGQmEsk98QJ30sHhdyC//0UvGKuR0KZuzZW4E0+k0rHDmos1Z5DmBEkA=="],
 
-    "@oxfmt/darwin-x64": ["@oxfmt/darwin-x64@0.16.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-EfiXFKEOV5gXgEatFK89OOoSmd8E9Xq83TcjPLWQNFBO4cgaQsfKmctpgJmJjQnoUwD7nQsm0ruj3ae7Gva8QA=="],
+    "@oxfmt/darwin-x64": ["@oxfmt/darwin-x64@0.17.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-trzidyzryKIdL/cLCYU9IwprgJegVBUrz1rqzOMe5is+qdgH/RxTCvhYUNFzxRHpil3g4QUYd2Ja831tc5Nehg=="],
 
-    "@oxfmt/linux-arm64-gnu": ["@oxfmt/linux-arm64-gnu@0.16.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-ydcNY9Fn/8TjVswANhdSh+zdgD3tiikNQA68bgXbENHuV3RyYql1qoOM1eGv5xeIVJfkPJme17MKQz3OwMFS4A=="],
+    "@oxfmt/linux-arm64-gnu": ["@oxfmt/linux-arm64-gnu@0.17.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-KlwzidgvHznbUaaglZT1goTS30osTV553pfbKve9B1PyTDkluNDfm/polOaf3SVLN7wL/NNLFZRMupvJ1eJXAw=="],
 
-    "@oxfmt/linux-arm64-musl": ["@oxfmt/linux-arm64-musl@0.16.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-I9WeYe1/YnrfXgXVaKkZITZzil0G0g9IknS2KJbq1lOnpTw3dwViXZ7XMa2cq6Mv7S+4SoDImb7fLQ59AfVX/w=="],
+    "@oxfmt/linux-arm64-musl": ["@oxfmt/linux-arm64-musl@0.17.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-+tbYJTocF4BNLaQQbc/xrBWTNgiU6zmYeF4NvRDxuuQjDOnmUZPn0EED3PZBRJyg4/YllhplHDo8x+gfcb9G3A=="],
 
-    "@oxfmt/linux-x64-gnu": ["@oxfmt/linux-x64-gnu@0.16.0", "", { "os": "linux", "cpu": "x64" }, "sha512-Szg9lJtZdN5FoCnNbl3N/2pJv8d056NUmk51m60E2tZV7rvwRTrNC8HPc2sVdb1Ti5ogsicpZDYSWA3cwIrJIQ=="],
+    "@oxfmt/linux-x64-gnu": ["@oxfmt/linux-x64-gnu@0.17.0", "", { "os": "linux", "cpu": "x64" }, "sha512-pEmv7zJIw2HpnA4Tn1xrfJNGi2wOH2+usT14Pkvf/c5DdB+pOir6k/5jzfe70+V3nEtmtV9Lm+spndN/y6+X7A=="],
 
-    "@oxfmt/linux-x64-musl": ["@oxfmt/linux-x64-musl@0.16.0", "", { "os": "linux", "cpu": "x64" }, "sha512-5koN8nl21ZxOADaMxXHT+mt3YjfXe1nsa23Fanf9aY7B0hcQ6rXYCZ7r5vmpoTtzW/US3aaVcRFZE1cyof+lKw=="],
+    "@oxfmt/linux-x64-musl": ["@oxfmt/linux-x64-musl@0.17.0", "", { "os": "linux", "cpu": "x64" }, "sha512-+DrFSCZWyFdtEAWR5xIBTV8GX0RA9iB+y7ZlJPRAXrNG8TdBY9vc7/MIGolIgrkMPK4mGMn07YG/qEyPY+iKaw=="],
 
-    "@oxfmt/win32-arm64": ["@oxfmt/win32-arm64@0.16.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Jaesn+FYn+MudSmWJMPGBAa0PhQXo52Z0ZYeNfzbQP7v2GFbZBI3Cb87+K0aHGlpqK3VEJKXeIaASaTWlkgO1Q=="],
+    "@oxfmt/win32-arm64": ["@oxfmt/win32-arm64@0.17.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-FoUZRR7mVpTYIaY/qz2BYwzqMnL+HsUxmMWAIy6nl29UEkDgxNygULJ4rIGY4/Axne41fhtldLrSGBOpwNm3jA=="],
 
-    "@oxfmt/win32-x64": ["@oxfmt/win32-x64@0.16.0", "", { "os": "win32", "cpu": "x64" }, "sha512-1obVSlb5blwBKgSsE1mNxvcq1pK9I6aXpZDy5d6jjGdrru33dHrH1ASChrcxwCukkToH2SxwYmnzAto0xeuZlw=="],
+    "@oxfmt/win32-x64": ["@oxfmt/win32-x64@0.17.0", "", { "os": "win32", "cpu": "x64" }, "sha512-fBIcUpHmCwf3leWlo0cYwLb9Pd2mzxQlZYJX9dD9nylPvsxOnsy9fmsaflpj34O0JbQJN3Y0SRkoaCcHHlxFww=="],
 
-    "@oxlint-tsgolint/darwin-arm64": ["@oxlint-tsgolint/darwin-arm64@0.8.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BhCcCtddJyQL1fvkGmQqqLfZzJg3vRHMHz0x06juPJupo/3HQOEz46iUXlfLiW1SbcwiRSzxWRGLXM3TiVxNPg=="],
+    "@oxlint-tsgolint/darwin-arm64": ["@oxlint-tsgolint/darwin-arm64@0.8.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-aygL+K1tOIDXkGncB8q6DbwQjK6CD81sfsUNmhQUcYNNgpOAc88BWyCR3Si8/nlu4sQOdydmfjeVJqJsHaQUxQ=="],
 
-    "@oxlint-tsgolint/darwin-x64": ["@oxlint-tsgolint/darwin-x64@0.8.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-PqA/jb+zdR31fLvQnQ1TRm/pDEmYhPUn504+UxBu8EfuYWxDeRXr7E34PphJpYwE+RlqKLfthbuYVbVaGjx6yw=="],
+    "@oxlint-tsgolint/darwin-x64": ["@oxlint-tsgolint/darwin-x64@0.8.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-rc4iOtwir3eK+f4eh8EzYyVvtwNlkIP+7WkVfkFydNJ1wzzrAZvn2TT1C9U6vcFaaDp2aDM3jie3ZwmMghQxbA=="],
 
-    "@oxlint-tsgolint/linux-arm64": ["@oxlint-tsgolint/linux-arm64@0.8.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-Dk62XzusCxnnEG82AB10LWpGq2ikdsjk9r0C9k5u8SUGfbXDID27Jbo9NCG0/ob+uG/SGdJKGAuY9rVYXO0/Mg=="],
+    "@oxlint-tsgolint/linux-arm64": ["@oxlint-tsgolint/linux-arm64@0.8.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-Wbdr640YAG7++2GAeHGDDijA69XwC3xQRp4hgaz6wR+JK6VWXQpeaHKW8v9axNLH9AVlnjUbEpZSh2MPkOpF3Q=="],
 
-    "@oxlint-tsgolint/linux-x64": ["@oxlint-tsgolint/linux-x64@0.8.3", "", { "os": "linux", "cpu": "x64" }, "sha512-yKNhHL1r2Xl59Av8UmE0ZeA89SojTyK/ByNleFhGFhLzIvEGJHFbC7jMGHMokfnrh73tR83g8KHNEz6iP8Iw/w=="],
+    "@oxlint-tsgolint/linux-x64": ["@oxlint-tsgolint/linux-x64@0.8.4", "", { "os": "linux", "cpu": "x64" }, "sha512-nWg57xz4xA++COoEb26RnwiMOOA+wfzipOSfqz/xSCwEXQDKryXfYMl7no7a3MsneHP2f4/JbOrDHbYishm3rw=="],
 
-    "@oxlint-tsgolint/win32-arm64": ["@oxlint-tsgolint/win32-arm64@0.8.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-UC2oUZ2MtaJ7jWP0kHtzx4Rkw+nTykGtncv72xKphFooKJWXi4MSQuVQ7RTsbmZa4poPYkYW1vaQayQU8Q586Q=="],
+    "@oxlint-tsgolint/win32-arm64": ["@oxlint-tsgolint/win32-arm64@0.8.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-LwRTv/30zlms4BaJrfW+ZnihdIvOku0Rrdo0FfMwSt7HlYfZdoB1yibTkC8yLfRlnbxyR0d57AQPjRasKAgyyQ=="],
 
-    "@oxlint-tsgolint/win32-x64": ["@oxlint-tsgolint/win32-x64@0.8.3", "", { "os": "win32", "cpu": "x64" }, "sha512-EACSsZjLe7l8VYXIGZGuqrJMIZymE/zDsmaQRy1MXeuWqg4F89zKh7b7KTBCiOLpkapkHiVWGCPqkoVZ2Lyvnw=="],
+    "@oxlint-tsgolint/win32-x64": ["@oxlint-tsgolint/win32-x64@0.8.4", "", { "os": "win32", "cpu": "x64" }, "sha512-jg2OezQ4Wwe+B3bOAUWH3CQdu/r5XtYwG/mwmgueL4KLmbJyO47w40hjBESHHgD8057BuHhJrf7lZpZN80bdzw=="],
 
-    "@oxlint/darwin-arm64": ["@oxlint/darwin-arm64@1.31.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-HqoYNH5WFZRdqGUROTFGOdBcA9y/YdHNoR/ujlyVO53it+q96dujbgKEvlff/WEuo4LbDKBrKLWKTKvOd/VYdg=="],
+    "@oxlint/darwin-arm64": ["@oxlint/darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-yrqPmZYu5Qb+49h0P5EXVIq8VxYkDDM6ZQrWzlh16+UGFcD8HOXs4oF3g9RyfaoAbShLCXooSQsM/Ifwx8E/eQ=="],
 
-    "@oxlint/darwin-x64": ["@oxlint/darwin-x64@1.31.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-gNq+JQXBCkYKQhmJEgSNjuPqmdL8yBEX3v0sueLH3g5ym4OIrNO7ml1M7xzCs0zhINQCR9MsjMJMyBNaF1ed+g=="],
+    "@oxlint/darwin-x64": ["@oxlint/darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-pQRZrJG/2nAKc3IuocFbaFFbTDlQsjz2WfivRsMn0hw65EEsSuM84WMFMiAfLpTGyTICeUtHZLHlrM5lzVr36A=="],
 
-    "@oxlint/linux-arm64-gnu": ["@oxlint/linux-arm64-gnu@1.31.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-cRmttpr3yHPwbrvtPNlv+0Zw2Oeh0cU902iMI4fFW9ylbW/vUAcz6DvzGMCYZbII8VDiwQ453SV5AA8xBgMbmw=="],
+    "@oxlint/linux-arm64-gnu": ["@oxlint/linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-tyomSmU2DzwcTmbaWFmStHgVfRmJDDvqcIvcw4fRB1YlL2Qg/XaM4NJ0m2bdTap38gxD5FSxSgCo0DkQ8GTolg=="],
 
-    "@oxlint/linux-arm64-musl": ["@oxlint/linux-arm64-musl@1.31.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0p7vn0hdMdNPIUzemw8f1zZ2rRZ/963EkK3o4P0KUXOPgleo+J9ZIPH7gcHSHtyrNaBifN03wET1rH4SuWQYnA=="],
+    "@oxlint/linux-arm64-musl": ["@oxlint/linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0W46dRMaf71OGE4+Rd+GHfS1uF/UODl5Mef6871pMhN7opPGfTI2fKJxh9VzRhXeSYXW/Z1EuCq9yCfmIJq+5Q=="],
 
-    "@oxlint/linux-x64-gnu": ["@oxlint/linux-x64-gnu@1.31.0", "", { "os": "linux", "cpu": "x64" }, "sha512-vNIbpSwQ4dwN0CUmojG7Y91O3CXOf0Kno7DSTshk/JJR4+u8HNVuYVjX2qBRk0OMc4wscJbEd7wJCl0VJOoCOw=="],
+    "@oxlint/linux-x64-gnu": ["@oxlint/linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-5+6myVCBOMvM62rDB9T3CARXUvIwhGqte6E+HoKRwYaqsxGUZ4bh3pItSgSFwHjLGPrvADS11qJUkk39eQQBzQ=="],
 
-    "@oxlint/linux-x64-musl": ["@oxlint/linux-x64-musl@1.31.0", "", { "os": "linux", "cpu": "x64" }, "sha512-4avnH09FJRTOT2cULdDPG0s14C+Ku4cnbNye6XO7rsiX6Bprz+aQblLA+1WLOr7UfC/0zF+jnZ9K5VyBBJy9Kw=="],
+    "@oxlint/linux-x64-musl": ["@oxlint/linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-qwQlwYYgVIC6ScjpUwiKKNyVdUlJckrfwPVpIjC9mvglIQeIjKuuyaDxUZWIOc/rEzeCV/tW6tcbehLkfEzqsw=="],
 
-    "@oxlint/win32-arm64": ["@oxlint/win32-arm64@1.31.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-mQaD5H93OUpxiGjC518t5wLQikf0Ur5mQEKO2VoTlkp01gqmrQ+hyCLOzABlsAIAeDJD58S9JwNOw4KFFnrqdw=="],
+    "@oxlint/win32-arm64": ["@oxlint/win32-arm64@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-7qYZF9CiXGtdv8Z/fBkgB5idD2Zokht67I5DKWH0fZS/2R232sDqW2JpWVkXltk0+9yFvmvJ0ouJgQRl9M3S2g=="],
 
-    "@oxlint/win32-x64": ["@oxlint/win32-x64@1.31.0", "", { "os": "win32", "cpu": "x64" }, "sha512-AS/h58HfloccRlVs7P3zbyZfxNS62JuE8/3fYGjkiRlR1ZoDxdqmz5QgLEn+YxxFUTMmclGAPMFHg9z2Pk315A=="],
+    "@oxlint/win32-x64": ["@oxlint/win32-x64@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-XW1xqCj34MEGJlHteqasTZ/LmBrwYIgluhNW0aP+XWkn90+stKAq3W/40dvJKbMK9F7o09LPCuMVtUW7FIUuiA=="],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.41", "", {}, "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g=="],
 
@@ -161,7 +161,7 @@
 
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
 
-    "@types/bun": ["@types/bun@1.3.3", "", { "dependencies": { "bun-types": "1.3.3" } }, "sha512-ogrKbJ2X5N0kWLLFKeytG0eHDleBYtngtlbu9cyBKFtNL3cnpDZkNdQj8flVf6WTZUX5ulI9AY1oa7ljhSrp+g=="],
+    "@types/bun": ["@types/bun@1.3.4", "", { "dependencies": { "bun-types": "1.3.4" } }, "sha512-EEPTKXHP+zKGPkhRLv+HI0UEX8/o+65hqARxLy8Ov5rIxMBPNTjeZww00CIihrIQGEQBYg+0roO5qOnS/7boGA=="],
 
     "@types/node": ["@types/node@24.10.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ=="],
 
@@ -169,7 +169,7 @@
 
     "axios": ["axios@1.13.2", "", { "dependencies": { "follow-redirects": "^1.15.6", "form-data": "^4.0.4", "proxy-from-env": "^1.1.0" } }, "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA=="],
 
-    "bun-types": ["bun-types@1.3.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-z3Xwlg7j2l9JY27x5Qn3Wlyos8YAp0kKRlrePAOjgjMGS5IG6E7Jnlx736vH9UVI4wUICwwhC9anYL++XeOgTQ=="],
+    "bun-types": ["bun-types@1.3.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-5ua817+BZPZOlNaRgGBpZJOSAQ9RQ17pkwPD0yR7CfJg+r8DgIILByFifDTa+IPDDxzf5VNhtNlcKqFzDgJvlQ=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
@@ -243,11 +243,11 @@
 
     "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
 
-    "oxfmt": ["oxfmt@0.16.0", "", { "optionalDependencies": { "@oxfmt/darwin-arm64": "0.16.0", "@oxfmt/darwin-x64": "0.16.0", "@oxfmt/linux-arm64-gnu": "0.16.0", "@oxfmt/linux-arm64-musl": "0.16.0", "@oxfmt/linux-x64-gnu": "0.16.0", "@oxfmt/linux-x64-musl": "0.16.0", "@oxfmt/win32-arm64": "0.16.0", "@oxfmt/win32-x64": "0.16.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-uRnnBAN0zH07FXSfvSKbIw+Jrohv4Px2RwNiZOGI4/pvns4sx0+k4WSt+tqwd7bDeoWaXiGmhZgnbK63hi6hVQ=="],
+    "oxfmt": ["oxfmt@0.17.0", "", { "optionalDependencies": { "@oxfmt/darwin-arm64": "0.17.0", "@oxfmt/darwin-x64": "0.17.0", "@oxfmt/linux-arm64-gnu": "0.17.0", "@oxfmt/linux-arm64-musl": "0.17.0", "@oxfmt/linux-x64-gnu": "0.17.0", "@oxfmt/linux-x64-musl": "0.17.0", "@oxfmt/win32-arm64": "0.17.0", "@oxfmt/win32-x64": "0.17.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-12Rmq2ub61rUZ3Pqnsvmo99rRQ6hQJwQsjnFnbvXYLMrlIsWT6SFVsrjAkBBrkXXSHv8ePIpKQ0nZph5KDrOqw=="],
 
-    "oxlint": ["oxlint@1.31.0", "", { "optionalDependencies": { "@oxlint/darwin-arm64": "1.31.0", "@oxlint/darwin-x64": "1.31.0", "@oxlint/linux-arm64-gnu": "1.31.0", "@oxlint/linux-arm64-musl": "1.31.0", "@oxlint/linux-x64-gnu": "1.31.0", "@oxlint/linux-x64-musl": "1.31.0", "@oxlint/win32-arm64": "1.31.0", "@oxlint/win32-x64": "1.31.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.8.1" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint", "oxc_language_server": "bin/oxc_language_server" } }, "sha512-U+Z3VShi1zuLF2Hz/pm4vWJUBm5sDHjwSzj340tz4tS2yXg9H5PTipsZv+Yu/alg6Z7EM2cZPKGNBZAvmdfkQg=="],
+    "oxlint": ["oxlint@1.32.0", "", { "optionalDependencies": { "@oxlint/darwin-arm64": "1.32.0", "@oxlint/darwin-x64": "1.32.0", "@oxlint/linux-arm64-gnu": "1.32.0", "@oxlint/linux-arm64-musl": "1.32.0", "@oxlint/linux-x64-gnu": "1.32.0", "@oxlint/linux-x64-musl": "1.32.0", "@oxlint/win32-arm64": "1.32.0", "@oxlint/win32-x64": "1.32.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.8.1" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint", "oxc_language_server": "bin/oxc_language_server" } }, "sha512-HYDQCga7flsdyLMUIxTgSnEx5KBxpP9VINB8NgO+UjV80xBiTQXyVsvjtneMT3ZBLMbL0SlG/Dm03XQAsEshMA=="],
 
-    "oxlint-tsgolint": ["oxlint-tsgolint@0.8.3", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "0.8.3", "@oxlint-tsgolint/darwin-x64": "0.8.3", "@oxlint-tsgolint/linux-arm64": "0.8.3", "@oxlint-tsgolint/linux-x64": "0.8.3", "@oxlint-tsgolint/win32-arm64": "0.8.3", "@oxlint-tsgolint/win32-x64": "0.8.3" }, "bin": { "tsgolint": "bin/tsgolint.js" } }, "sha512-R/pqgXPC4DRQyrODa5xyqiHZNiCcX+R96Bu3qsAMkeSJOKarL8wEszNVNlR+bx8gbWYjPDFuRnlYionTHNjFPA=="],
+    "oxlint-tsgolint": ["oxlint-tsgolint@0.8.4", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "0.8.4", "@oxlint-tsgolint/darwin-x64": "0.8.4", "@oxlint-tsgolint/linux-arm64": "0.8.4", "@oxlint-tsgolint/linux-x64": "0.8.4", "@oxlint-tsgolint/win32-arm64": "0.8.4", "@oxlint-tsgolint/win32-x64": "0.8.4" }, "bin": { "tsgolint": "bin/tsgolint.js" } }, "sha512-0eyQ83M0JpeA8a4SPk61xwxBw+N9jMolDCLmzoD9J8HcL3BGTEcOLb5Ud7nCcmM3hSYzO91RqNPHayESG+os2A=="],
 
     "p-limit": ["p-limit@4.0.0", "", { "dependencies": { "yocto-queue": "^1.0.0" } }, "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ=="],
 

--- a/examples/elysia-sqlite/package.json
+++ b/examples/elysia-sqlite/package.json
@@ -1,27 +1,27 @@
 {
-  "$schema": "https://json.schemastore.org/package.json",
-  "name": "elysia-sqlite-example",
-  "version": "1.0.0",
-  "description": "Example API using Elysia, SQLite, and Filtron for dynamic filtering",
-  "type": "module",
-  "private": true,
-  "scripts": {
-    "start": "bun run src/index.ts",
-    "dev": "bun --watch run src/index.ts",
-    "test": "bun test"
-  },
-  "dependencies": {
-    "@faker-js/faker": "10.1.0",
-    "@filtron/core": "workspace:*",
-    "@filtron/sql": "workspace:*",
-    "elysia": "1.4.18"
-  },
-  "devDependencies": {
-    "@types/bun": "catalog:",
-    "typescript": "catalog:"
-  },
-  "engines": {
-    "bun": ">=1.1.0"
-  },
-  "packageManager": "bun@1.3.3"
+	"$schema": "https://json.schemastore.org/package.json",
+	"name": "elysia-sqlite-example",
+	"version": "1.0.0",
+	"description": "Example API using Elysia, SQLite, and Filtron for dynamic filtering",
+	"type": "module",
+	"private": true,
+	"scripts": {
+		"start": "bun run src/index.ts",
+		"dev": "bun --watch run src/index.ts",
+		"test": "bun test"
+	},
+	"dependencies": {
+		"@faker-js/faker": "10.1.0",
+		"@filtron/core": "workspace:*",
+		"@filtron/sql": "workspace:*",
+		"elysia": "1.4.18"
+	},
+	"devDependencies": {
+		"@types/bun": "catalog:",
+		"typescript": "catalog:"
+	},
+	"engines": {
+		"bun": ">=1.1.0"
+	},
+	"packageManager": "bun@1.3.3"
 }

--- a/examples/elysia-sqlite/tsconfig.json
+++ b/examples/elysia-sqlite/tsconfig.json
@@ -1,9 +1,9 @@
 {
-  "compilerOptions": {
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "types": ["@types/bun"],
-    "strict": true,
-    "skipLibCheck": true
-  }
+	"compilerOptions": {
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"types": ["@types/bun"],
+		"strict": true,
+		"skipLibCheck": true,
+	},
 }

--- a/package.json
+++ b/package.json
@@ -1,47 +1,47 @@
 {
-  "$schema": "https://json.schemastore.org/package.json",
-  "name": "filtron",
-  "version": "1.0.0",
-  "private": true,
-  "description": "Fast, type-safe query language parser for filtering data in real-time APIs",
-  "homepage": "https://github.com/jbergstroem/filtron#readme",
-  "bugs": {
-    "url": "https://github.com/jbergstroem/filtron/issues"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/jbergstroem/filtron.git"
-  },
-  "license": "MIT",
-  "author": "Johan Bergström <bugs@bergstroem.nu>",
-  "workspaces": {
-    "packages": [
-      "packages/core",
-      "packages/sql",
-      "packages/js",
-      "packages/benchmark",
-      "examples/elysia-sqlite"
-    ],
-    "catalog": {
-      "@types/bun": "1.3.3",
-      "mitata": "1.0.34",
-      "typescript": "5.9.3"
-    }
-  },
-  "scripts": {
-    "bench": "cd packages/core && bun run bench",
-    "build": "bun run --filter '@filtron/core' build && bun run --filter '!@filtron/core' build",
-    "lint": "oxlint && oxfmt --check",
-    "test": "bun test"
-  },
-  "devDependencies": {
-    "oxfmt": "0.16.0",
-    "oxlint": "1.31.0",
-    "oxlint-tsgolint": "0.8.3"
-  },
-  "engines": {
-    "node": ">=20.0.0",
-    "bun": ">=1.1.0"
-  },
-  "packageManager": "bun@1.3.3"
+	"$schema": "https://json.schemastore.org/package.json",
+	"name": "filtron",
+	"version": "1.0.0",
+	"private": true,
+	"description": "Fast, type-safe query language parser for filtering data in real-time APIs",
+	"homepage": "https://github.com/jbergstroem/filtron#readme",
+	"bugs": {
+		"url": "https://github.com/jbergstroem/filtron/issues"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/jbergstroem/filtron.git"
+	},
+	"license": "MIT",
+	"author": "Johan Bergström <bugs@bergstroem.nu>",
+	"workspaces": {
+		"packages": [
+			"packages/core",
+			"packages/sql",
+			"packages/js",
+			"packages/benchmark",
+			"examples/elysia-sqlite"
+		],
+		"catalog": {
+			"@types/bun": "1.3.4",
+			"mitata": "1.0.34",
+			"typescript": "5.9.3"
+		}
+	},
+	"scripts": {
+		"bench": "cd packages/core && bun run bench",
+		"build": "bun run --filter '@filtron/core' build && bun run --filter '!@filtron/core' build",
+		"lint": "oxlint && oxfmt --check",
+		"test": "bun test"
+	},
+	"devDependencies": {
+		"oxfmt": "0.17.0",
+		"oxlint": "1.32.0",
+		"oxlint-tsgolint": "0.8.4"
+	},
+	"engines": {
+		"node": ">=20.0.0",
+		"bun": ">=1.1.0"
+	},
+	"packageManager": "bun@1.3.3"
 }

--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -1,29 +1,29 @@
 {
-  "$schema": "https://json.schemastore.org/package.json",
-  "name": "@filtron/benchmark",
-  "version": "1.0.0",
-  "private": true,
-  "description": "Continuous performance benchmarks for Filtron using tinybench + CodSpeed",
-  "type": "module",
-  "scripts": {
-    "bench": "bun run bench:core && bun run bench:sql && bun run bench:js",
-    "bench:core": "node core.bench.ts",
-    "bench:sql": "node sql.bench.ts",
-    "bench:js": "node js.bench.ts"
-  },
-  "dependencies": {
-    "@codspeed/tinybench-plugin": "5.0.1",
-    "@filtron/core": "workspace:*",
-    "@filtron/js": "workspace:*",
-    "@filtron/sql": "workspace:*",
-    "tinybench": "5.1.0"
-  },
-  "devDependencies": {
-    "@types/bun": "catalog:"
-  },
-  "engines": {
-    "node": ">=20.0.0",
-    "bun": ">=1.1.0"
-  },
-  "packageManager": "bun@1.3.3"
+	"$schema": "https://json.schemastore.org/package.json",
+	"name": "@filtron/benchmark",
+	"version": "1.0.0",
+	"private": true,
+	"description": "Continuous performance benchmarks for Filtron using tinybench + CodSpeed",
+	"type": "module",
+	"scripts": {
+		"bench": "bun run bench:core && bun run bench:sql && bun run bench:js",
+		"bench:core": "node core.bench.ts",
+		"bench:sql": "node sql.bench.ts",
+		"bench:js": "node js.bench.ts"
+	},
+	"dependencies": {
+		"@codspeed/tinybench-plugin": "5.0.1",
+		"@filtron/core": "workspace:*",
+		"@filtron/js": "workspace:*",
+		"@filtron/sql": "workspace:*",
+		"tinybench": "5.1.0"
+	},
+	"devDependencies": {
+		"@types/bun": "catalog:"
+	},
+	"engines": {
+		"node": ">=20.0.0",
+		"bun": ">=1.1.0"
+	},
+	"packageManager": "bun@1.3.3"
 }

--- a/packages/benchmark/tsconfig.json
+++ b/packages/benchmark/tsconfig.json
@@ -1,9 +1,9 @@
 {
-  "compilerOptions": {
-    "module": "ESNext",
-    "target": "ESNext",
-    "moduleResolution": "bundler",
-    "strict": true,
-    "skipLibCheck": true
-  }
+	"compilerOptions": {
+		"module": "ESNext",
+		"target": "ESNext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"skipLibCheck": true,
+	},
 }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -151,11 +151,11 @@ function handleAST(node: ASTNode) {
 
 Filtron uses a hand-written recursive descent parser optimized for speed:
 
-| Query Type | Parse Time    | Throughput       |
-| ---------- | ------------- | ---------------- |
-| Simple     | ~250-350ns    | 3-4M ops/sec     |
-| Medium     | ~600-1700ns   | 600K-1.6M ops/sec |
-| Complex    | ~1.5-3μs      | 350-700K ops/sec |
+| Query Type | Parse Time  | Throughput        |
+| ---------- | ----------- | ----------------- |
+| Simple     | ~250-350ns  | 3-4M ops/sec      |
+| Medium     | ~600-1700ns | 600K-1.6M ops/sec |
+| Complex    | ~1.5-3μs    | 350-700K ops/sec  |
 
 Run benchmarks: `bun run bench`
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,69 +1,69 @@
 {
-  "$schema": "https://json.schemastore.org/package.json",
-  "name": "@filtron/core",
-  "version": "1.1.0",
-  "description": "A fast, type-safe query language parser for filtering data in real-time APIs",
-  "keywords": [
-    "filtron",
-    "query",
-    "parser",
-    "filter",
-    "query-language",
-    "typescript",
-    "filtering",
-    "search",
-    "query-parser"
-  ],
-  "homepage": "https://github.com/jbergstroem/filtron#readme",
-  "bugs": {
-    "url": "https://github.com/jbergstroem/filtron/issues"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/jbergstroem/filtron.git",
-    "directory": "packages/core"
-  },
-  "license": "MIT",
-  "author": "Johan Bergström <bugs@bergstroem.nu>",
-  "type": "module",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
-    }
-  },
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "files": [
-    "dist",
-    "README.md",
-    "LICENSE"
-  ],
-  "scripts": {
-    "bench": "bun run build && bun --expose-gc run benchmark.ts",
-    "build": "bun build --minify --splitting --sourcemap=linked --outdir=dist index.ts && tsc --emitDeclarationOnly --declaration --declarationMap --outDir dist --skipLibCheck",
-    "prepublishOnly": "bun run build && bun test",
-    "test": "bun test",
-    "typecheck": "tsc --noemit"
-  },
-  "devDependencies": {
-    "@types/bun": "catalog:",
-    "mitata": "catalog:",
-    "typescript": "catalog:"
-  },
-  "peerDependencies": {
-    "typescript": ">=5.0.0"
-  },
-  "peerDependenciesMeta": {
-    "typescript": {
-      "optional": true
-    }
-  },
-  "engines": {
-    "node": ">=20.0.0",
-    "bun": ">=1.1.0"
-  },
-  "packageManager": "bun@1.3.3"
+	"$schema": "https://json.schemastore.org/package.json",
+	"name": "@filtron/core",
+	"version": "1.1.0",
+	"description": "A fast, type-safe query language parser for filtering data in real-time APIs",
+	"keywords": [
+		"filtron",
+		"query",
+		"parser",
+		"filter",
+		"query-language",
+		"typescript",
+		"filtering",
+		"search",
+		"query-parser"
+	],
+	"homepage": "https://github.com/jbergstroem/filtron#readme",
+	"bugs": {
+		"url": "https://github.com/jbergstroem/filtron/issues"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/jbergstroem/filtron.git",
+		"directory": "packages/core"
+	},
+	"license": "MIT",
+	"author": "Johan Bergström <bugs@bergstroem.nu>",
+	"type": "module",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"default": "./dist/index.js"
+		}
+	},
+	"main": "./dist/index.js",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"files": [
+		"dist",
+		"README.md",
+		"LICENSE"
+	],
+	"scripts": {
+		"bench": "bun run build && bun --expose-gc run benchmark.ts",
+		"build": "bun build --minify --splitting --sourcemap=linked --outdir=dist index.ts && tsc --emitDeclarationOnly --declaration --declarationMap --outDir dist --skipLibCheck",
+		"prepublishOnly": "bun run build && bun test",
+		"test": "bun test",
+		"typecheck": "tsc --noemit"
+	},
+	"devDependencies": {
+		"@types/bun": "catalog:",
+		"mitata": "catalog:",
+		"typescript": "catalog:"
+	},
+	"peerDependencies": {
+		"typescript": ">=5.0.0"
+	},
+	"peerDependenciesMeta": {
+		"typescript": {
+			"optional": true
+		}
+	},
+	"engines": {
+		"node": ">=20.0.0",
+		"bun": ">=1.1.0"
+	},
+	"packageManager": "bun@1.3.3"
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,14 +1,14 @@
 {
-  "compilerOptions": {
-    "target": "ES2021",
-    "module": "ESNext",
-    "lib": ["ES2021"],
-    "moduleResolution": "bundler",
-    "strict": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "outDir": "./dist"
-  },
-  "include": ["src/**/*", "index.ts"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+	"compilerOptions": {
+		"target": "ES2021",
+		"module": "ESNext",
+		"lib": ["ES2021"],
+		"moduleResolution": "bundler",
+		"strict": true,
+		"skipLibCheck": true,
+		"declaration": true,
+		"outDir": "./dist",
+	},
+	"include": ["src/**/*", "index.ts"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts"],
 }

--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -43,12 +43,12 @@ Converts a Filtron AST to a predicate function for use with `Array.filter()`.
 
 **Options:**
 
-| Option | Type | Description |
-|--------|------|-------------|
-| `allowedFields` | `string[]` | Restrict queryable fields (throws if field not in list) |
-| `fieldAccessor` | `(obj, field) => unknown` | Custom field value accessor |
-| `caseInsensitive` | `boolean` | Case-insensitive string comparisons (default: `false`) |
-| `fieldMapping` | `Record<string, string>` | Map query field names to object property names |
+| Option            | Type                      | Description                                             |
+| ----------------- | ------------------------- | ------------------------------------------------------- |
+| `allowedFields`   | `string[]`                | Restrict queryable fields (throws if field not in list) |
+| `fieldAccessor`   | `(obj, field) => unknown` | Custom field value accessor                             |
+| `caseInsensitive` | `boolean`                 | Case-insensitive string comparisons (default: `false`)  |
+| `fieldMapping`    | `Record<string, string>`  | Map query field names to object property names          |
 
 ```typescript
 const filter = toFilter(ast, {

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,69 +1,69 @@
 {
-  "$schema": "https://json.schemastore.org/package.json",
-  "name": "@filtron/js",
-  "version": "1.0.0",
-  "description": "In-memory JavaScript array filtering using Filtron AST",
-  "keywords": [
-    "filtron",
-    "filter",
-    "javascript",
-    "array",
-    "predicate",
-    "ast",
-    "typescript"
-  ],
-  "homepage": "https://github.com/jbergstroem/filtron#readme",
-  "bugs": {
-    "url": "https://github.com/jbergstroem/filtron/issues"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/jbergstroem/filtron.git",
-    "directory": "packages/js"
-  },
-  "license": "MIT",
-  "author": "Johan Bergström <bugs@bergstroem.nu>",
-  "type": "module",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
-    }
-  },
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "files": [
-    "dist",
-    "README.md",
-    "LICENSE"
-  ],
-  "scripts": {
-    "bench": "bun --expose-gc run benchmark.ts",
-    "build": "bun build --minify --splitting --sourcemap=linked --outdir=dist --external @filtron/core index.ts && tsc",
-    "prepublishOnly": "bun run build && bun test",
-    "test": "bun test",
-    "typecheck": "tsc --noemit"
-  },
-  "dependencies": {
-    "@filtron/core": "workspace:*"
-  },
-  "peerDependencies": {
-    "typescript": "catalog:"
-  },
-  "peerDependenciesMeta": {
-    "typescript": {
-      "optional": true
-    }
-  },
-  "devDependencies": {
-    "@types/bun": "catalog:",
-    "mitata": "catalog:"
-  },
-  "engines": {
-    "node": ">=20.0.0",
-    "bun": ">=1.1.0"
-  },
-  "packageManager": "bun@1.3.3"
+	"$schema": "https://json.schemastore.org/package.json",
+	"name": "@filtron/js",
+	"version": "1.0.0",
+	"description": "In-memory JavaScript array filtering using Filtron AST",
+	"keywords": [
+		"filtron",
+		"filter",
+		"javascript",
+		"array",
+		"predicate",
+		"ast",
+		"typescript"
+	],
+	"homepage": "https://github.com/jbergstroem/filtron#readme",
+	"bugs": {
+		"url": "https://github.com/jbergstroem/filtron/issues"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/jbergstroem/filtron.git",
+		"directory": "packages/js"
+	},
+	"license": "MIT",
+	"author": "Johan Bergström <bugs@bergstroem.nu>",
+	"type": "module",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"default": "./dist/index.js"
+		}
+	},
+	"main": "./dist/index.js",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"files": [
+		"dist",
+		"README.md",
+		"LICENSE"
+	],
+	"scripts": {
+		"bench": "bun --expose-gc run benchmark.ts",
+		"build": "bun build --minify --splitting --sourcemap=linked --outdir=dist --external @filtron/core index.ts && tsc",
+		"prepublishOnly": "bun run build && bun test",
+		"test": "bun test",
+		"typecheck": "tsc --noemit"
+	},
+	"dependencies": {
+		"@filtron/core": "workspace:*"
+	},
+	"peerDependencies": {
+		"typescript": "catalog:"
+	},
+	"peerDependenciesMeta": {
+		"typescript": {
+			"optional": true
+		}
+	},
+	"devDependencies": {
+		"@types/bun": "catalog:",
+		"mitata": "catalog:"
+	},
+	"engines": {
+		"node": ">=20.0.0",
+		"bun": ">=1.1.0"
+	},
+	"packageManager": "bun@1.3.3"
 }

--- a/packages/js/tsconfig.json
+++ b/packages/js/tsconfig.json
@@ -1,17 +1,17 @@
 {
-  "$schema": "https://json.schemastore.org/tsconfig",
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "strict": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "emitDeclarationOnly": true,
-    "outDir": "./dist",
-    "rootDir": ".",
-    "isolatedModules": true
-  },
-  "include": ["index.ts", "src/**/*.ts"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+	"$schema": "https://json.schemastore.org/tsconfig",
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"skipLibCheck": true,
+		"declaration": true,
+		"emitDeclarationOnly": true,
+		"outDir": "./dist",
+		"rootDir": ".",
+		"isolatedModules": true,
+	},
+	"include": ["index.ts", "src/**/*.ts"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts"],
 }

--- a/packages/sql/README.md
+++ b/packages/sql/README.md
@@ -37,12 +37,12 @@ Converts a Filtron AST to a parameterized SQL WHERE clause.
 
 **Options:**
 
-| Option | Type | Description |
-|--------|------|-------------|
-| `parameterStyle` | `'numbered'` \| `'question'` | Placeholder style: `$1` (default) or `?` |
-| `fieldMapper` | `(field) => string` | Transform field names to column names |
-| `valueMapper` | `(value) => value` | Transform values (useful for LIKE wildcards) |
-| `startIndex` | `number` | Starting parameter index (default: `1`) |
+| Option           | Type                         | Description                                  |
+| ---------------- | ---------------------------- | -------------------------------------------- |
+| `parameterStyle` | `'numbered'` \| `'question'` | Placeholder style: `$1` (default) or `?`     |
+| `fieldMapper`    | `(field) => string`          | Transform field names to column names        |
+| `valueMapper`    | `(value) => value`           | Transform values (useful for LIKE wildcards) |
+| `startIndex`     | `number`                     | Starting parameter index (default: `1`)      |
 
 ```typescript
 const { sql, params } = toSQL(ast, {

--- a/packages/sql/package.json
+++ b/packages/sql/package.json
@@ -1,73 +1,73 @@
 {
-  "$schema": "https://json.schemastore.org/package.json",
-  "name": "@filtron/sql",
-  "version": "1.1.0",
-  "description": "SQL WHERE clause generator for Filtron AST with parameterized queries",
-  "keywords": [
-    "filtron",
-    "sql",
-    "where-clause",
-    "query-builder",
-    "ast",
-    "typescript",
-    "duckdb",
-    "postgresql",
-    "mysql",
-    "sqlite"
-  ],
-  "homepage": "https://github.com/jbergstroem/filtron#readme",
-  "bugs": {
-    "url": "https://github.com/jbergstroem/filtron/issues"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/jbergstroem/filtron.git",
-    "directory": "packages/sql"
-  },
-  "license": "MIT",
-  "author": "Johan Bergström <bugs@bergstroem.nu>",
-  "type": "module",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
-    }
-  },
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "files": [
-    "dist",
-    "README.md",
-    "LICENSE"
-  ],
-  "scripts": {
-    "bench": "bun --expose-gc run benchmark.ts",
-    "build": "bun build --minify --splitting --sourcemap=linked --outdir=dist --external @filtron/core index.ts && tsc",
-    "prepublishOnly": "bun run build && bun test",
-    "test": "bun test",
-    "typecheck": "tsc --noemit"
-  },
-  "dependencies": {
-    "@filtron/core": "workspace:*"
-  },
-  "peerDependencies": {
-    "typescript": "catalog:"
-  },
-  "peerDependenciesMeta": {
-    "typescript": {
-      "optional": true
-    }
-  },
-  "devDependencies": {
-    "@types/bun": "catalog:",
-    "mitata": "catalog:",
-    "typescript": "catalog:"
-  },
-  "engines": {
-    "node": ">=20.0.0",
-    "bun": ">=1.1.0"
-  },
-  "packageManager": "bun@1.3.3"
+	"$schema": "https://json.schemastore.org/package.json",
+	"name": "@filtron/sql",
+	"version": "1.1.0",
+	"description": "SQL WHERE clause generator for Filtron AST with parameterized queries",
+	"keywords": [
+		"filtron",
+		"sql",
+		"where-clause",
+		"query-builder",
+		"ast",
+		"typescript",
+		"duckdb",
+		"postgresql",
+		"mysql",
+		"sqlite"
+	],
+	"homepage": "https://github.com/jbergstroem/filtron#readme",
+	"bugs": {
+		"url": "https://github.com/jbergstroem/filtron/issues"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/jbergstroem/filtron.git",
+		"directory": "packages/sql"
+	},
+	"license": "MIT",
+	"author": "Johan Bergström <bugs@bergstroem.nu>",
+	"type": "module",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"default": "./dist/index.js"
+		}
+	},
+	"main": "./dist/index.js",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"files": [
+		"dist",
+		"README.md",
+		"LICENSE"
+	],
+	"scripts": {
+		"bench": "bun --expose-gc run benchmark.ts",
+		"build": "bun build --minify --splitting --sourcemap=linked --outdir=dist --external @filtron/core index.ts && tsc",
+		"prepublishOnly": "bun run build && bun test",
+		"test": "bun test",
+		"typecheck": "tsc --noemit"
+	},
+	"dependencies": {
+		"@filtron/core": "workspace:*"
+	},
+	"peerDependencies": {
+		"typescript": "catalog:"
+	},
+	"peerDependenciesMeta": {
+		"typescript": {
+			"optional": true
+		}
+	},
+	"devDependencies": {
+		"@types/bun": "catalog:",
+		"mitata": "catalog:",
+		"typescript": "catalog:"
+	},
+	"engines": {
+		"node": ">=20.0.0",
+		"bun": ">=1.1.0"
+	},
+	"packageManager": "bun@1.3.3"
 }

--- a/packages/sql/tsconfig.json
+++ b/packages/sql/tsconfig.json
@@ -1,17 +1,17 @@
 {
-  "$schema": "https://json.schemastore.org/tsconfig",
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "strict": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "emitDeclarationOnly": true,
-    "outDir": "./dist",
-    "rootDir": ".",
-    "isolatedModules": true
-  },
-  "include": ["index.ts", "src/**/*.ts"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+	"$schema": "https://json.schemastore.org/tsconfig",
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"skipLibCheck": true,
+		"declaration": true,
+		"emitDeclarationOnly": true,
+		"outDir": "./dist",
+		"rootDir": ".",
+		"isolatedModules": true,
+	},
+	"include": ["index.ts", "src/**/*.ts"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts"],
 }


### PR DESCRIPTION
In this version of oxfmt, it now supports linting a wide array of formats, so we include the output as part of bumping the dependency.