### PR TITLE
fix: ignore pinning node in ci benchmark

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,4 @@
 {
-<<<<<<< HEAD
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"baseBranchPatterns": ["main"],
 	"timezone": "Europe/Lisbon",


### PR DESCRIPTION
Second attempt at ignoring the node dependency.

Refs: https://github.com/jbergstroem/filtron/pull/71