### PR TITLE
chore: refactor codecov actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
           bun-version: ${{ matrix.version }}
 
       - if: matrix.setup == 'deno'
-        uses: denoland/setup-deno@v2
+        uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2
         with:
           deno-version: ${{ matrix.version }}
 


### PR DESCRIPTION
## What

Replace `codecov/test-results-action` with `codecov/codecov-action` and passing `report_type: test_results` (which defaults to coverage).

## Why

Upstream has deprecated  `codecov/test-results-action` and suggests this approach. This also allows us to only download one action.