### PR TITLE
feat: add deno 2.6 to the e2e test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,9 @@ jobs:
           - setup: deno
             version: "2.5.x"
             test_cmd: deno eval
+          - setup: deno
+            version: "2.6.x"
+            test_cmd: deno eval
     name: e2e (${{ matrix.setup }} ${{ matrix.version }})
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6


### PR DESCRIPTION
## What

Add Deno 2.6 to the test matrix.

## Why

Deno 2.6 was recently released and we should cover it in the e2e test suite.

