### PR TITLE
chore: only run the e2e test in pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,7 @@ jobs:
           disable_search: true
 
   e2e:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     strategy:
       matrix:


### PR DESCRIPTION
## What

Only run e2e tests in PR branches.

## Why

No need to waste CI cycles in main/other non-pr branches.