### PR TITLE
chore: use type-aware checks in oxlint

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 	"scripts": {
 		"bench": "cd packages/core && bun run bench",
 		"build": "bun run --filter '@filtron/core' build && bun run --filter '!@filtron/core' build",
-		"lint": "oxlint; oxfmt --check; exit $(( $? ))",
+		"lint": "oxlint --type-aware --type-check; oxfmt --check; exit $(( $? ))",
 		"test": "bun test"
 	},
 	"devDependencies": {

--- a/packages/js/src/filter.ts
+++ b/packages/js/src/filter.ts
@@ -299,7 +299,7 @@ function generateComparison(
 
 		default:
 			const _exhaustive: never = node.operator;
-			throw new Error(`Unknown operator: ${node.operator}`);
+			throw new Error(`Unknown operator: ${_exhaustive as string}`);
 	}
 }
 

--- a/packages/sql/overhead.ts
+++ b/packages/sql/overhead.ts
@@ -28,7 +28,21 @@ console.log(`Testing ${iterations.toLocaleString()} iterations per query\n`);
 let totalOverhead = 0;
 let totalCount = 0;
 
-const overheadResults = [];
+interface OverheadResult {
+	"Query Complexity": string;
+	"Parse Only": string;
+	"Parse+SQL": string;
+	Overhead: string;
+	Impact: string;
+}
+
+interface ConversionResult {
+	"Conversion Type": string;
+	"Time per op": string;
+	Throughput: string;
+}
+
+const overheadResults: OverheadResult[] = [];
 
 for (const testCase of testCases) {
 	// Measure parse only
@@ -89,7 +103,7 @@ const sqlTestCases = [
 	},
 ];
 
-const conversionResults = [];
+const conversionResults: ConversionResult[] = [];
 
 for (const testCase of sqlTestCases) {
 	const start = performance.now();

--- a/scripts/verify-tag.ts
+++ b/scripts/verify-tag.ts
@@ -85,7 +85,9 @@ export async function readPackageJson(packageDir: string): Promise<PackageJson> 
 		});
 		return packageJson.default as PackageJson;
 	} catch (error) {
-		throw new Error(`Could not read package.json in ${packageDir}: ${error}`);
+		throw new Error(
+			`Could not read package.json in ${packageDir}: ${error instanceof Error ? error.message : String(error)}`,
+		);
 	}
 }
 


### PR DESCRIPTION
### Why

Using type-checks in oxlint is very convenience and avoids the `tsc` round-trip

### What

Use type-checks via `oxlint` and fix the errors emitted by the linter. The warnings remain since they seem to be false positives.

### Notes

No AI was used while making this PR