### PR TITLE
fix: use `npm` for publishing to the repository

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,7 +28,7 @@
 			"enabled": false
 		},
 		{
-		  "managerFilePatterns": ["/^\\.github/workflows/[^/]+\\.yml$/"],
+			"matchFileNames": ["/^\\.github/workflows/[^/]+\\.yml$/"],
 			"matchDepNames": ["node"],
 			"enabled": false
 		}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,6 +58,7 @@ jobs:
       - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
           node-version: 24
+          package-manager-cache: false
           registry-url: "https://registry.npmjs.org"
       - run: |
           cd "${{ matrix.package.dir }}"


### PR DESCRIPTION

### Why

Bun cannot publish to the npm registry when using provenance/OIDC.

### What

Switch to npm for now.

Refs: https://github.com/jbergstroem/filtron/issues/114
