### PR TITLE
chore: @filtron/core v1.3.1

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://json.schemastore.org/package.json",
 	"name": "@filtron/core",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"description": "Filtron parses human-friendly filter strings into structured queries you can use anywhere — SQL databases, in-memory arrays, or your own custom backend.",
 	"keywords": [
 		"filter",


### PR DESCRIPTION
### Why

New release

### What

Update package.json.

### Notes

Somewhat silly that I have to bump the version, but I prefer the "forward only" approach instead of rebuilding `scripts/verify-tag.ts` and shifting the commit the tag points to.