### PR TITLE
fix: build @filtron/core as part of publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,6 +52,7 @@ jobs:
           bun-version-file: package.json
           no-cache: true
       - run: bun ci
+      - run: bun run --filter=@filtron/core build
       - run: |
           cd "${{ matrix.package.dir }}"
           bun run build


### PR DESCRIPTION
### Why

Publishing the sub packages fails in CI.

### What

The packages that depend on `@filtron/core` will emit type errors if they are not available as part of building/emitting their own types.

### Notes

No AI involved in this PR.