### PR TITLE
fix: publish package contents manually

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,4 +64,4 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - run: |
           cd "${{ matrix.package.dir }}"
-          npm publish "filtron-${{ matrix.package.tag }}.tgz" --provenance --access public
+          npm publish filtron-${{ matrix.package.name }}-${{ matrix.package.version }}.tgz --provenance --access public


### PR DESCRIPTION

### Why

The packages recently published via CI contains bun-specific syntax in `package.json`, making other package managers (such as npm) fail on install.

### What

When publishing the package, let Bun create the tarball so all transformations that are specific to the format bun supports in `package.json` is applied.

Refs: https://github.com/jbergstroem/filtron/issues/114