### PR TITLE
feat: expose and use tag in github ci

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,4 +64,4 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - run: |
           cd "${{ matrix.package.dir }}"
-          npm publish filtron-${{ matrix.package.name }}-${{ matrix.package.version }}.tgz --provenance --access public
+          npm publish ./filtron-${{ matrix.package.tag }}.tgz --provenance --access public

--- a/scripts/verify-tag.test.ts
+++ b/scripts/verify-tag.test.ts
@@ -227,6 +227,7 @@ describe("Verify tag", () => {
 				packages.push({
 					name: `@filtron/${shortName}`,
 					version,
+					tag: tag,
 					dir: packageDir,
 				});
 			}
@@ -235,11 +236,13 @@ describe("Verify tag", () => {
 			expect(packages[0]).toEqual({
 				name: "@filtron/core",
 				version: "1.0.0",
+				tag: "core-1.0.0",
 				dir: "packages/core",
 			});
 			expect(packages[1]).toEqual({
 				name: "@filtron/sql",
 				version: "2.0.0",
+				tag: "sql-2.0.0",
 				dir: "packages/sql",
 			});
 		});

--- a/scripts/verify-tag.ts
+++ b/scripts/verify-tag.ts
@@ -30,6 +30,7 @@ export interface PackageJson {
 
 export interface PackageInfo {
 	name: string;
+	tag: string;
 	version: string;
 	dir: string;
 }
@@ -147,7 +148,7 @@ export async function verifyTag(
 
 /**
  * Process a single tag and return package info
- * Git tag uses short name (e.g., "core@1.0.0")
+ * Git tag uses short name (e.g., "core-1.0.0")
  * Returns scoped npm package name (e.g., "@filtron/core")
  */
 async function processTag(tag: string): Promise<PackageInfo> {
@@ -157,6 +158,7 @@ async function processTag(tag: string): Promise<PackageInfo> {
 
 	return {
 		name: scopedPackageName,
+		tag: tag,
 		version,
 		dir: packageDir,
 	};


### PR DESCRIPTION
### Why

The tag name is incorrect in the ci publish action.

### What

Instead of constructing the name for the tarball in CI we expose it in the verify-tag script.
