### PR TITLE
chore(docs): add benchmark to monorepo table

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,8 +220,8 @@ try {
 
 Filtron is a monorepo with focused packages:
 
-| Package                                    | Version                                                 | Bundle Size                                                                       | Description                                    |
-| ------------------------------------------ | ------------------------------------------------------- | --------------------------------------------------------------------------------- | ---------------------------------------------- |
+| Package                                    | Version                                                 | Bundle Size                                                                    | Description                                    |
+| ------------------------------------------ | ------------------------------------------------------- | ------------------------------------------------------------------------------ | ---------------------------------------------- |
 | [@filtron/core](./packages/core)           | ![npm](https://img.shields.io/npm/v/@filtron/core)      | ![npm bundle size](https://img.shields.io/bundlephobia/min/@filtron/core)      | Core parser — parses expressions into an AST   |
 | [@filtron/sql](./packages/sql)             | ![npm](https://img.shields.io/npm/v/@filtron/sql)       | ![npm bundle size](https://img.shields.io/bundlephobia/min/@filtron/sql)       | Generates parameterized SQL WHERE clauses      |
 | [@filtron/js](./packages/js)               | ![npm](https://img.shields.io/npm/v/@filtron/js)        | ![npm bundle size](https://img.shields.io/bundlephobia/min/@filtron/js)        | Creates filter functions for JavaScript arrays |


### PR DESCRIPTION

### Why

The benchmark package was missing from the table.

### What

Add it. Also, add version/size info.
