### PR TITLE
feat: expose parse failure position

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,7 +13,7 @@
  */
 
 // Parser functions
-export { parse, parseOrThrow } from "./parser";
+export { parse, parseOrThrow, FiltronParseError } from "./parser";
 export type { ParseResult, ParseSuccess, ParseError } from "./parser";
 
 // AST type definitions

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -7,6 +7,20 @@ import { LexerError } from "./lexer";
 import { parseQuery, ParseError as RDParseError } from "./rd-parser";
 
 /**
+ * Error thrown by parseOrThrow when parsing fails.
+ * Includes the position in the query where the error occurred.
+ */
+export class FiltronParseError extends Error {
+	constructor(
+		message: string,
+		public position?: number,
+	) {
+		super(message);
+		this.name = "FiltronParseError";
+	}
+}
+
+/**
  * Result of a successful parse operation
  */
 export interface ParseSuccess {
@@ -33,7 +47,7 @@ export type ParseResult = ParseSuccess | ParseError;
  * Parses a Filtron query string into an Abstract Syntax Tree (AST).
  *
  * @param query - The Filtron query string to parse
- * @returns A ParseResult containing either the AST or an error message
+ * @returns A ParseResult containing either the AST or an error
  *
  * @example
  * ```typescript
@@ -80,7 +94,7 @@ export const parse = (query: string): ParseResult => {
  *
  * @param query - The Filtron query string to parse
  * @returns The parsed AST
- * @throws Error if parsing fails
+ * @throws FiltronParseError if parsing fails, with position information
  *
  * @example
  * ```typescript
@@ -88,7 +102,9 @@ export const parse = (query: string): ParseResult => {
  *   const ast = parseOrThrow('age > 18');
  *   console.log(ast);
  * } catch (error) {
- *   console.error('Parse failed:', error.message);
+ *   if (error instanceof FiltronParseError) {
+ *     console.error('Parse failed at position', error.position, ':', error.message);
+ *   }
  * }
  * ```
  */
@@ -99,5 +115,5 @@ export const parseOrThrow = (query: string): ASTNode => {
 		return result.ast;
 	}
 
-	throw new Error(`Failed to parse Filtron query: ${result.error}`);
+	throw new FiltronParseError(`Failed to parse Filtron query: ${result.error}`, result.position);
 };


### PR DESCRIPTION

### Why

This can be useful to provide feedback about where the parsing fails.

### What

Expose what position the parser fails at.