### PR TITLE
feat(core): export Lexer and token types

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Full TypeScript types are exported for building custom AST consumers.
 
 Filtron currently uses a hand-written lexer and recursive descent parser and has no runtime dependencies (~9 KB minified). We continuously monitor performance with [CodSpeed](https://codspeed.io/) to test out new optimizations.
 
-The AST syntax is seen as stable and any changes follows strict semantic versioning (we for instance switched from a PEG parser to a hand-written recursive descent parser after the initial release).
+The AST syntax is seen as stable and any changes follows strict semantic versioning (we for instance switched from a PEG parser to a recursive descent parser after the initial release).
 
 | Query Complexity | Parse Time | Throughput        |
 | ---------------- | ---------- | ----------------- |

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -142,6 +142,19 @@ import type {
 } from "@filtron/core";
 ```
 
+The Lexer types are also available if you want to use them for syntax highlighting or other purposes:
+
+```typescript
+import { Lexer, LexerError } from "@filtron/core";
+import type {
+  Token,
+  TokenType,
+  StringToken,
+  NumberToken,
+  BooleanToken,
+} from "@filtron/core";
+```
+
 ### AST structure
 
 | Node Type      | Fields                       | Example input          |
@@ -184,7 +197,7 @@ parse('age > 18 AND status = "active"')
 
 ## Performance
 
-Hand-written recursive descent parser. ~9 KB minified, zero dependencies.
+Recursive descent parser. ~9 KB minified, zero dependencies.
 
 | Query complexity | Parse time | Throughput        |
 | ---------------- | ---------- | ----------------- |

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,10 @@
 export { parse, parseOrThrow, FiltronParseError } from "./parser";
 export type { ParseResult, ParseSuccess, ParseError } from "./parser";
 
+// Lexer for tokenization
+export { Lexer, LexerError } from "./lexer";
+export type { Token, TokenType, StringToken, NumberToken, BooleanToken } from "./lexer";
+
 // AST type definitions
 export type {
 	ASTNode,


### PR DESCRIPTION
### Why

By having access to the lexer types its easier to build things like syntax highlighters.

### What

Export Lexer and its token types.