### PR TITLE
chore(docs): update parseOrThrow documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,12 +207,14 @@ order.shipping.address.country = "PT"
 Use `parseOrThrow` if you prefer exceptions over result objects:
 
 ```typescript
-import { parseOrThrow } from "@filtron/core";
+import { parseOrThrow, FiltronParseError } from "@filtron/core";
 
 try {
   const ast = parseOrThrow('age > 18 AND status = "active"');
 } catch (error) {
-  console.error(error.message);
+  if (error instanceof FiltronParseError) {
+    console.error(error.message, error.position);  // error description and position
+  }
 }
 ```
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -98,21 +98,27 @@ Parses a filter expression and returns a result object.
 const result = parse('age > 18');
 
 if (result.success) {
-  result.ast;   // ASTNode
+  result.ast;      // ASTNode
 } else {
-  result.error; // string
+  result.error;    // string - error message
+  result.position; // number - position in input where error occurred
 }
 ```
 
 ### `parseOrThrow(input: string): ASTNode`
 
-Parses a filter expression, throwing on invalid input.
+Parses a filter expression, throwing `FiltronParseError` on invalid input.
 
 ```typescript
+import { parseOrThrow, FiltronParseError } from "@filtron/core";
+
 try {
   const ast = parseOrThrow('age > 18');
 } catch (error) {
-  console.error(error.message);
+  if (error instanceof FiltronParseError) {
+    console.error(error.message);  // error description
+    console.error(error.position); // position in input where error occurred
+  }
 }
 ```
 
@@ -121,24 +127,25 @@ try {
 All AST types are exported for building custom consumers:
 
 ```typescript
-import type {
-  ParseResult,
-  ASTNode,
-  AndExpression,
-  OrExpression,
-  NotExpression,
-  ComparisonExpression,
-  ExistsExpression,
-  BooleanFieldExpression,
-  OneOfExpression,
-  NotOneOfExpression,
-  RangeExpression,
-  Value,
-  ComparisonOperator,
-  StringValue,
-  NumberValue,
-  BooleanValue,
-  IdentifierValue,
+import {
+  FiltronParseError,        // Error class thrown by parseOrThrow
+  type ParseResult,
+  type ASTNode,
+  type AndExpression,
+  type OrExpression,
+  type NotExpression,
+  type ComparisonExpression,
+  type ExistsExpression,
+  type BooleanFieldExpression,
+  type OneOfExpression,
+  type NotOneOfExpression,
+  type RangeExpression,
+  type Value,
+  type ComparisonOperator,
+  type StringValue,
+  type NumberValue,
+  type BooleanValue,
+  type IdentifierValue,
 } from "@filtron/core";
 ```
 


### PR DESCRIPTION
### Why

The documentation was out of sync with the recent changes to the error handling.

### What

Update it.