### PR TITLE
feat: textmate language bundle

### DIFF
--- a/packages/core/filtron.tmLanguage.json
+++ b/packages/core/filtron.tmLanguage.json
@@ -1,0 +1,57 @@
+{
+	"name": "Filtron",
+	"scopeName": "source.filtron",
+	"patterns": [
+		{
+			"include": "#keywords"
+		},
+		{
+			"include": "#operators"
+		},
+		{
+			"include": "#strings"
+		},
+		{
+			"include": "#numbers"
+		},
+		{
+			"include": "#fields"
+		},
+		{
+			"include": "#brackets"
+		}
+	],
+	"repository": {
+		"keywords": {
+			"match": "\\b(AND|OR|NOT|EXISTS|TRUE|FALSE)\\b",
+			"name": "keyword.control.filtron"
+		},
+		"operators": {
+			"match": "(>=|<=|!=|!:|:|=|>|<|~|\\?|\\.\\.)",
+			"name": "keyword.operator.filtron"
+		},
+		"strings": {
+			"begin": "\"",
+			"end": "\"",
+			"name": "string.quoted.double.filtron",
+			"patterns": [
+				{
+					"match": "\\\\.",
+					"name": "constant.character.escape.filtron"
+				}
+			]
+		},
+		"numbers": {
+			"match": "-?\\d+(\\.\\d+)?",
+			"name": "constant.numeric.filtron"
+		},
+		"fields": {
+			"match": "[a-zA-Z_][a-zA-Z0-9_.]*",
+			"name": "variable.other.filtron"
+		},
+		"brackets": {
+			"match": "[\\[\\]\\(\\)]",
+			"name": "punctuation.bracket.filtron"
+		}
+	}
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,6 +27,7 @@
 	},
 	"files": [
 		"dist",
+		"filtron.tmLanguage.json",
 		"LICENSE",
 		"README.md"
 	],
@@ -39,7 +40,8 @@
 			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js",
 			"default": "./dist/index.js"
-		}
+		},
+		"./filtron.tmLanguage.json": "./filtron.tmLanguage.json"
 	},
 	"scripts": {
 		"bench": "bun run build && bun --expose-gc run benchmark.ts",


### PR DESCRIPTION
### Why

tmbundles is commonly used to build grammar/highlighting across editors and highlighters

### What

Add a tmbundle to the core package.

### Notes

- Claude helped with the first revision, I revised it.