### PR TITLE
chore(deps): prepare for typescript 6

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,12 +11,6 @@
         "oxlint": "1.48.0",
         "oxlint-tsgolint": "0.14.0",
       },
-      "peerDependencies": {
-        "typescript": "catalog:",
-      },
-      "optionalPeers": [
-        "typescript",
-      ],
     },
     "examples/elysia-sqlite": {
       "name": "elysia-sqlite-example",
@@ -122,7 +116,7 @@
   "catalog": {
     "@types/bun": "1.3.9",
     "oxfmt": "0.33.0",
-    "typescript": "5.9.3",
+    "typescript": "6.0.0-beta",
   },
   "packages": {
     "@borewit/text-codec": ["@borewit/text-codec@0.2.1", "", {}, "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw=="],
@@ -1129,7 +1123,7 @@
 
     "typed-array-length": ["typed-array-length@1.0.7", "", { "dependencies": { "call-bind": "^1.0.7", "for-each": "^0.3.3", "gopd": "^1.0.1", "is-typed-array": "^1.1.13", "possible-typed-array-names": "^1.0.0", "reflect.getprototypeof": "^1.0.6" } }, "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.0-beta", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-CldZdztDpQRLM1HC6WDQjQkQN5Ub5zRau737a1diGh3lPmb9oRsaWHk1y5iqK0o7+1bNJ0oXfEGRkAogFZBL+Q=="],
 
     "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 
@@ -1231,11 +1225,15 @@
 
     "csso/css-tree": ["css-tree@1.0.0-alpha.29", "", { "dependencies": { "mdn-data": "~1.1.0", "source-map": "^0.5.3" } }, "sha512-sRNb1XydwkW9IOci6iB2xmy8IGCj6r/fr+JWitvJ2JxQRPzN3T4AGGVWCMlVmVwM1gtgALJRmGIlWv5ppnGGkg=="],
 
+    "elysia/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
     "fs-plus/async": ["async@1.5.2", "", {}, "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w=="],
 
     "fs-plus/mkdirp": ["mkdirp@0.5.6", "", { "dependencies": { "minimist": "^1.2.6" }, "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw=="],
 
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "knip/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 

--- a/examples/elysia-sqlite/tsconfig.json
+++ b/examples/elysia-sqlite/tsconfig.json
@@ -1,9 +1,6 @@
 {
 	"compilerOptions": {
-		"module": "ESNext",
-		"moduleResolution": "bundler",
 		"types": ["@types/bun"],
-		"strict": true,
 		"skipLibCheck": true
 	}
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"catalog": {
 			"@types/bun": "1.3.9",
 			"oxfmt": "0.33.0",
-			"typescript": "5.9.3"
+			"typescript": "6.0.0-beta"
 		}
 	},
 	"scripts": {
@@ -40,9 +40,6 @@
 		"oxfmt": "catalog:",
 		"oxlint": "1.48.0",
 		"oxlint-tsgolint": "0.14.0"
-	},
-	"peerDependencies": {
-		"typescript": "catalog:"
 	},
 	"peerDependenciesMeta": {
 		"typescript": {

--- a/packages/benchmark/tsconfig.json
+++ b/packages/benchmark/tsconfig.json
@@ -1,18 +1,10 @@
 {
-	"$schema": "https://json.schemastore.org/tsconfig",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"target": "ES2022",
-		"module": "ESNext",
-		"moduleResolution": "bundler",
-		"strict": true,
-		"skipLibCheck": true,
-		"declaration": true,
+		"types": ["@types/bun"],
 		"declarationMap": true,
-		"emitDeclarationOnly": true,
 		"outDir": "./dist",
-		"rootDir": "./src",
-		"isolatedModules": true
+		"rootDir": "./src"
 	},
-	"include": ["src/**/*.ts"],
-	"exclude": ["node_modules", "dist"]
+	"include": ["src/**/*.ts"]
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,14 +1,7 @@
 {
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"target": "ES2021",
-		"module": "ESNext",
-		"lib": ["ES2021"],
-		"moduleResolution": "bundler",
-		"strict": true,
-		"skipLibCheck": true,
-		"declaration": true,
 		"outDir": "./dist"
 	},
-	"include": ["src/**/*", "index.ts"],
-	"exclude": ["node_modules", "dist", "**/*.test.ts"]
+	"include": ["src/**/*", "index.ts"]
 }

--- a/packages/js/tsconfig.json
+++ b/packages/js/tsconfig.json
@@ -1,17 +1,7 @@
 {
-	"$schema": "https://json.schemastore.org/tsconfig",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"target": "ES2022",
-		"module": "ESNext",
-		"moduleResolution": "bundler",
-		"strict": true,
-		"skipLibCheck": true,
-		"declaration": true,
-		"emitDeclarationOnly": true,
-		"outDir": "./dist",
-		"rootDir": ".",
-		"isolatedModules": true
+		"outDir": "./dist"
 	},
-	"include": ["index.ts", "src/**/*.ts"],
-	"exclude": ["node_modules", "dist", "**/*.test.ts"]
+	"include": ["index.ts", "src/**/*.ts"]
 }

--- a/packages/sql/tsconfig.json
+++ b/packages/sql/tsconfig.json
@@ -1,17 +1,7 @@
 {
-	"$schema": "https://json.schemastore.org/tsconfig",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"target": "ES2022",
-		"module": "ESNext",
-		"moduleResolution": "bundler",
-		"strict": true,
-		"skipLibCheck": true,
-		"declaration": true,
-		"emitDeclarationOnly": true,
-		"outDir": "./dist",
-		"rootDir": ".",
-		"isolatedModules": true
+		"outDir": "./dist"
 	},
-	"include": ["index.ts", "src/**/*.ts"],
-	"exclude": ["node_modules", "dist", "**/*.test.ts"]
+	"include": ["index.ts", "src/**/*.ts"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,12 @@
+{
+	"$schema": "https://json.schemastore.org/tsconfig",
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"skipLibCheck": true,
+		"declaration": true,
+		"emitDeclarationOnly": true,
+		"isolatedModules": true
+	},
+	"exclude": ["**/node_modules", "**/dist", "**/*.test.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,8 @@
 {
+	"extends": "./tsconfig.base.json",
 	"compilerOptions": {
-		"target": "ES2021",
-		"module": "ESNext",
-		"lib": ["ES2021"],
-		"moduleResolution": "bundler",
-		"strict": true,
-		"skipLibCheck": true
+		"types": ["@types/bun"],
+		"noEmit": true
 	},
 	"include": ["scripts/*.ts"]
 }


### PR DESCRIPTION
### Why

Typescript 6 is coming, wanted to review how a migration would look like.

### What

Split out shared configuration directives into a `tsconfig.base.json` and then adapt all configs to Typescript 6 standard.