### PR TITLE
chore(ci): test against the latest two deno minors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,14 +83,12 @@ jobs:
           - setup: bun
             version: "1.3"
             test_cmd: bun -e
+          # deno has no LTS releases; track the latest two minors
           - setup: deno
-            version: "2.5.x"
+            version: "2.8.x"
             test_cmd: deno eval
           - setup: deno
-            version: "2.6.x"
-            test_cmd: deno eval
-          - setup: deno
-            version: "2.7.x"
+            version: "2.9.x"
             test_cmd: deno eval
     name: e2e (${{ matrix.setup }} ${{ matrix.version }})
     steps:


### PR DESCRIPTION
### Why

The e2e matrix pinned deno 2.5.x through 2.7.x, which has gone stale: latest is 2.9. Deno has no LTS releases to anchor a support policy on.

### What

Track the latest two minors instead: 2.8.x and 2.9.x, with a comment in the matrix explaining the policy. Net one fewer matrix job.
