### PR TITLE
chore(conformance): add shared adapter conformance fixtures

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -54,6 +54,17 @@
         "typescript",
       ],
     },
+    "packages/conformance": {
+      "name": "@filtron/conformance",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@filtron/core": "workspace:*",
+        "@filtron/js": "workspace:*",
+        "@filtron/sql": "workspace:*",
+        "@types/bun": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
     "packages/core": {
       "name": "@filtron/core",
       "version": "2.0.0",
@@ -208,6 +219,8 @@
     "@faker-js/faker": ["@faker-js/faker@10.5.0", "", {}, "sha512-bsxD8WLS5lIj7aaoCx1YJkktqYj5vlBUE6HWzu2Q51ksrGJ0H737ECCKlFU7Yf8Br45z9t99frBp/J7kzbMPAg=="],
 
     "@filtron/benchmark": ["@filtron/benchmark@workspace:packages/benchmark"],
+
+    "@filtron/conformance": ["@filtron/conformance@workspace:packages/conformance"],
 
     "@filtron/core": ["@filtron/core@workspace:packages/core"],
 

--- a/packages/conformance/README.md
+++ b/packages/conformance/README.md
@@ -1,0 +1,18 @@
+# @filtron/conformance
+
+Shared conformance fixtures that every Filtron adapter runs in CI. Private, not published.
+
+Each case pins the intended behavior of a query across adapters:
+
+- the dataset ids a `@filtron/js` filter must match with default options
+- the WHERE clause and parameters `@filtron/sql` must generate with default options
+
+Cases run against a canonical dataset chosen so every operator discriminates: case variants, missing vs null vs empty values, a literal dotted property name, LIKE metacharacters in data, and negative/zero/float numbers.
+
+## Changing semantics
+
+Fixtures describe current behavior, including known divergences between adapters (marked with a `notes` field referencing the tracking issue). An intentional semantic change must update the affected fixtures in the same PR, which makes the change reviewable as a diff. A fixture failure without a fixture change is a regression.
+
+## Adding a case
+
+Add an entry to `cases` in [src/index.ts](./src/index.ts). Keep names kebab-case and unique. If the case documents an adapter divergence, say so in `notes` and link the issue.

--- a/packages/conformance/package.json
+++ b/packages/conformance/package.json
@@ -1,0 +1,25 @@
+{
+	"$schema": "https://json.schemastore.org/package.json",
+	"name": "@filtron/conformance",
+	"version": "1.0.0",
+	"private": true,
+	"description": "Shared conformance fixtures that all Filtron adapters must pass",
+	"license": "MIT",
+	"author": "Johan Bergström <bugs@bergstroem.nu>",
+	"type": "module",
+	"scripts": {
+		"test": "bun test"
+	},
+	"devDependencies": {
+		"@filtron/core": "workspace:*",
+		"@filtron/js": "workspace:*",
+		"@filtron/sql": "workspace:*",
+		"@types/bun": "catalog:",
+		"typescript": "catalog:"
+	},
+	"engines": {
+		"bun": ">=1.2.19",
+		"node": ">=20.0.0"
+	},
+	"packageManager": "bun@1.3.14"
+}

--- a/packages/conformance/src/index.test.ts
+++ b/packages/conformance/src/index.test.ts
@@ -1,0 +1,30 @@
+import { describe, test, expect } from "bun:test";
+import { parseOrThrow } from "@filtron/core";
+import { toFilter } from "@filtron/js";
+import { toSQL } from "@filtron/sql";
+import { cases, dataset } from "./index.js";
+
+const named = cases.map((c) => [c.name, c] as const);
+
+describe("conformance", () => {
+	test("case names are unique", () => {
+		const names = new Set(cases.map((c) => c.name));
+		expect(names.size).toBe(cases.length);
+	});
+
+	describe("@filtron/js", () => {
+		test.each(named)("%s", (_name, c) => {
+			const filter = toFilter(parseOrThrow(c.query));
+			const ids = dataset.filter(filter).map((r) => r.id);
+			expect(ids).toEqual(c.matches);
+		});
+	});
+
+	describe("@filtron/sql", () => {
+		test.each(named)("%s", (_name, c) => {
+			const result = toSQL(parseOrThrow(c.query));
+			expect(result.sql).toBe(c.sql);
+			expect(result.params).toEqual(c.params);
+		});
+	});
+});

--- a/packages/conformance/src/index.ts
+++ b/packages/conformance/src/index.ts
@@ -1,0 +1,371 @@
+/**
+ * Shared conformance fixtures for Filtron adapters
+ *
+ * Every case pins the current, intended behavior of the language across
+ * adapters: the ids a compiled filter must match against the canonical
+ * dataset, and the SQL an AST must generate with default options. Adapters
+ * run these in CI, so an intentional semantic change shows up as a fixture
+ * diff in the same PR that changes it. Known divergences between adapters
+ * carry a note referencing the tracking issue.
+ */
+
+/** A record in the canonical dataset */
+export type ConformanceRecord = Record<string, unknown> & { id: number };
+
+/** A single conformance case */
+export interface ConformanceCase {
+	/** Unique, kebab-case case name */
+	name: string;
+	/** The Filtron query under test */
+	query: string;
+	/** Dataset ids a @filtron/js filter with default options must match, in dataset order */
+	matches: number[];
+	/** WHERE clause @filtron/sql must generate with default options */
+	sql: string;
+	/** Parameters @filtron/sql must produce, in order */
+	params: (string | number | boolean)[];
+	/** Behavior worth calling out, including known adapter divergences */
+	notes?: string;
+}
+
+/**
+ * Canonical dataset. Values are chosen so each operator discriminates:
+ * case variants ("active"/"ACTIVE", "admin"/"Admin"), a missing vs null vs
+ * empty email, a literal dotted property name, LIKE metacharacters and an
+ * apostrophe in data, and negative/zero/float scores.
+ */
+export const dataset: ConformanceRecord[] = [
+	{
+		id: 1,
+		name: "Alice Johnson",
+		age: 25,
+		score: 4.5,
+		status: "active",
+		role: "admin",
+		verified: true,
+		premium: true,
+		suspended: false,
+		email: "alice@example.com",
+	},
+	{
+		id: 2,
+		name: "Bob Smith",
+		age: 17,
+		score: 2,
+		status: "pending",
+		role: "user",
+		verified: false,
+		premium: false,
+		suspended: false,
+		email: null,
+	},
+	{
+		id: 3,
+		name: "Charlie Brown",
+		age: 30,
+		score: 3.25,
+		status: "inactive",
+		role: "moderator",
+		verified: true,
+		premium: false,
+		suspended: true,
+	},
+	{
+		id: 4,
+		name: "Dana White",
+		age: 42,
+		score: -1.5,
+		status: "active",
+		role: "user",
+		verified: true,
+		premium: false,
+		suspended: false,
+		email: "dana@example.com",
+	},
+	{
+		id: 5,
+		name: "Eve Adams",
+		age: 18,
+		score: 0,
+		status: "deleted",
+		role: "user",
+		verified: false,
+		premium: true,
+		suspended: true,
+		email: "",
+	},
+	{
+		id: 6,
+		name: "frank o'neil",
+		age: 65,
+		score: 5,
+		status: "ACTIVE",
+		role: "Admin",
+		verified: true,
+		premium: true,
+		suspended: false,
+		email: "frank@example.com",
+	},
+	{
+		id: 7,
+		name: "Grace_Hopper",
+		age: 85,
+		score: 10.75,
+		status: "retired",
+		role: "admin",
+		verified: true,
+		premium: true,
+		suspended: false,
+		email: "grace@navy.mil",
+		"profile.level": 9,
+	},
+	{
+		id: 8,
+		name: "Hank 100%",
+		age: 33,
+		score: 3,
+		status: "active",
+		role: "user",
+		verified: false,
+		premium: false,
+		suspended: false,
+		email: "hank@example.com",
+	},
+];
+
+export const cases: ConformanceCase[] = [
+	{
+		name: "equals-string",
+		query: 'status = "active"',
+		matches: [1, 4, 8],
+		sql: "status = $1",
+		params: ["active"],
+	},
+	{
+		name: "colon-identifier",
+		query: "role : admin",
+		matches: [1, 7],
+		sql: "role = $1",
+		params: ["admin"],
+	},
+	{
+		name: "not-equals",
+		query: 'status != "active"',
+		matches: [2, 3, 5, 6, 7],
+		sql: "status != $1",
+		params: ["active"],
+	},
+	{
+		name: "greater-than",
+		query: "age > 30",
+		matches: [4, 6, 7, 8],
+		sql: "age > $1",
+		params: [30],
+	},
+	{
+		name: "greater-than-or-equal",
+		query: "age >= 30",
+		matches: [3, 4, 6, 7, 8],
+		sql: "age >= $1",
+		params: [30],
+	},
+	{
+		name: "less-than-float",
+		query: "score < 3",
+		matches: [2, 4, 5],
+		sql: "score < $1",
+		params: [3],
+	},
+	{
+		name: "less-than-or-equal",
+		query: "age <= 18",
+		matches: [2, 5],
+		sql: "age <= $1",
+		params: [18],
+	},
+	{
+		name: "contains",
+		query: 'name ~ "an"',
+		matches: [4, 6, 8],
+		sql: "name LIKE $1",
+		params: ["an"],
+		notes:
+			"Known divergence (#282): js matches substrings, sql emits LIKE without wildcards so a database would match the exact string only.",
+	},
+	{
+		name: "case-sensitive-default",
+		query: 'status = "ACTIVE"',
+		matches: [6],
+		sql: "status = $1",
+		params: ["ACTIVE"],
+	},
+	{
+		name: "range",
+		query: "age = 18..30",
+		matches: [1, 3, 5],
+		sql: "age BETWEEN $1 AND $2",
+		params: [18, 30],
+	},
+	{
+		name: "one-of-small",
+		query: 'status : ["active", "pending"]',
+		matches: [1, 2, 4, 8],
+		sql: "status IN ($1, $2)",
+		params: ["active", "pending"],
+	},
+	{
+		name: "not-one-of",
+		query: "role !: [admin, moderator]",
+		matches: [2, 4, 5, 6, 8],
+		sql: "role NOT IN ($1, $2)",
+		params: ["admin", "moderator"],
+	},
+	{
+		name: "one-of-large",
+		query: "age : [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]",
+		matches: [2, 5],
+		sql: "age IN ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)",
+		params: [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
+		notes: "More than 10 values exercises the Set lookup path in @filtron/js.",
+	},
+	{
+		name: "exists-question-mark",
+		query: "email?",
+		matches: [1, 4, 5, 6, 7, 8],
+		sql: "email IS NOT NULL",
+		params: [],
+		notes: "Empty string exists; null and missing keys do not.",
+	},
+	{
+		name: "exists-keyword",
+		query: "email EXISTS",
+		matches: [1, 4, 5, 6, 7, 8],
+		sql: "email IS NOT NULL",
+		params: [],
+	},
+	{
+		name: "boolean-shorthand",
+		query: "verified",
+		matches: [1, 3, 4, 6, 7],
+		sql: "verified = $1",
+		params: [true],
+	},
+	{
+		name: "compare-boolean",
+		query: "premium = true",
+		matches: [1, 5, 6, 7],
+		sql: "premium = $1",
+		params: [true],
+	},
+	{
+		name: "not",
+		query: "NOT suspended",
+		matches: [1, 2, 4, 6, 7, 8],
+		sql: "NOT (suspended = $1)",
+		params: [true],
+	},
+	{
+		name: "and",
+		query: 'status = "active" AND verified',
+		matches: [1, 4],
+		sql: "(status = $1 AND verified = $2)",
+		params: ["active", true],
+	},
+	{
+		name: "or",
+		query: "role : admin OR role : moderator",
+		matches: [1, 3, 7],
+		sql: "(role = $1 OR role = $2)",
+		params: ["admin", "moderator"],
+	},
+	{
+		name: "and-chain",
+		query: "verified AND premium AND age > 21",
+		matches: [1, 6, 7],
+		sql: "((verified = $1 AND premium = $2) AND age > $3)",
+		params: [true, true, 21],
+	},
+	{
+		name: "parens-grouping",
+		query: '(role : admin OR role : moderator) AND status = "active"',
+		matches: [1],
+		sql: "((role = $1 OR role = $2) AND status = $3)",
+		params: ["admin", "moderator", "active"],
+	},
+	{
+		name: "precedence-and-over-or",
+		query: "role : admin OR role : moderator AND verified",
+		matches: [1, 3, 7],
+		sql: "(role = $1 OR (role = $2 AND verified = $3))",
+		params: ["admin", "moderator", true],
+	},
+	{
+		name: "not-inside-and",
+		query: "NOT suspended AND verified",
+		matches: [1, 4, 6, 7],
+		sql: "(NOT (suspended = $1) AND verified = $2)",
+		params: [true, true],
+	},
+	{
+		name: "dotted-field-literal",
+		query: "profile.level > 5",
+		matches: [7],
+		sql: "profile.level > $1",
+		params: [5],
+		notes:
+			"The default js accessor reads the literal 'profile.level' property; nested traversal requires nestedAccessor.",
+	},
+	{
+		name: "apostrophe-in-string",
+		query: `name ~ "o'neil"`,
+		matches: [6],
+		sql: "name LIKE $1",
+		params: ["o'neil"],
+	},
+	{
+		name: "like-metacharacters-in-value",
+		query: 'name ~ "100%"',
+		matches: [8],
+		sql: "name LIKE $1",
+		params: ["100%"],
+		notes: "The % passes through as a parameter; escaping is the caller's job via escapeLike.",
+	},
+	{
+		name: "negative-number",
+		query: "score = -1.5",
+		matches: [4],
+		sql: "score = $1",
+		params: [-1.5],
+	},
+	{
+		name: "zero-boundary",
+		query: "score < 0",
+		matches: [4],
+		sql: "score < $1",
+		params: [0],
+	},
+	{
+		name: "string-number-guard",
+		query: 'age > "18"',
+		matches: [],
+		sql: "age > $1",
+		params: ["18"],
+		notes:
+			"Known divergence: js type-guards numeric comparisons and matches nothing for a string target; sql defers comparison semantics to the database.",
+	},
+	{
+		name: "no-matches",
+		query: 'status = "nope"',
+		matches: [],
+		sql: "status = $1",
+		params: ["nope"],
+	},
+	{
+		name: "escape-sequences",
+		query: 'name = "line\\nbreak"',
+		matches: [],
+		sql: "name = $1",
+		params: ["line\nbreak"],
+		notes: "The lexer resolves the escape; adapters receive the actual newline.",
+	},
+];

--- a/packages/conformance/tsconfig.json
+++ b/packages/conformance/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"types": ["@types/bun"],
+		"noEmit": true
+	},
+	"include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
### Why

First 3.0 building block. Nothing currently forces adapters to agree on semantics. With the AST and grammar changes queued for 3.0, every semantic change needs to be visible as a reviewable diff rather than discovered later.

### What

New private workspace package `@filtron/conformance`:

- A canonical 8-record dataset built so every operator discriminates (case variants, missing vs null vs empty values, a literal dotted property name, LIKE metacharacters and an apostrophe in data, negative/zero/float numbers).
- 32 cases covering every operator and construct: all comparisons, range, small/large one-of (both lookup paths), not-one-of, both exists spellings, boolean shorthand, NOT/AND/OR, chains, parens, precedence, escapes, and edge values.
- Each case asserts the ids a `@filtron/js` filter must match and the exact SQL + params `@filtron/sql` must generate, with default options. 65 tests total, picked up by `bun test` from the root so CI enforces them.

Known divergences are pinned as current behavior and annotated with the tracking issue rather than papered over:

- `~` matches substrings in js but emits a wildcard-free LIKE in sql
- js type-guards numeric comparisons against string targets, sql defers to the database

Closes: https://github.com/jbergstroem/filtron/issues/286
Refs: https://github.com/jbergstroem/filtron/issues/282
