### PR TITLE
chore(sql): `~` should contains by default

### DIFF
--- a/examples/elysia-sqlite/src/index-e2e.test.ts
+++ b/examples/elysia-sqlite/src/index-e2e.test.ts
@@ -100,7 +100,7 @@ describe("Elysia E2E Tests", () => {
 
 	test("should filter with contains operator", async () => {
 		const response = await fetch(
-			`${getBaseUrl()}/users?filter=${encodeURIComponent('name ~ "%a%"')}`,
+			`${getBaseUrl()}/users?filter=${encodeURIComponent('name ~ "a"')}`,
 		);
 		const data = await response.json();
 

--- a/packages/conformance/src/index.ts
+++ b/packages/conformance/src/index.ts
@@ -188,9 +188,8 @@ export const cases: ConformanceCase[] = [
 		query: 'name ~ "an"',
 		matches: [4, 6, 8],
 		sql: "name LIKE $1",
-		params: ["an"],
-		notes:
-			"Known divergence (#282): js matches substrings, sql emits LIKE without wildcards so a database would match the exact string only.",
+		params: ["%an%"],
+		notes: "~ is substring-contains in both adapters; sql wraps the parameter in % wildcards.",
 	},
 	{
 		name: "case-sensitive-default",
@@ -320,15 +319,17 @@ export const cases: ConformanceCase[] = [
 		query: `name ~ "o'neil"`,
 		matches: [6],
 		sql: "name LIKE $1",
-		params: ["o'neil"],
+		params: ["%o'neil%"],
+		notes: "The apostrophe stays in the parameter; only LIKE metacharacters are escaped.",
 	},
 	{
 		name: "like-metacharacters-in-value",
 		query: 'name ~ "100%"',
 		matches: [8],
 		sql: "name LIKE $1",
-		params: ["100%"],
-		notes: "The % passes through as a parameter; escaping is the caller's job via escapeLike.",
+		params: ["%100\\%%"],
+		notes:
+			"sql escapes LIKE metacharacters (%, _, \\) by default, so the % matches literally, as in js.",
 	},
 	{
 		name: "negative-number",

--- a/packages/sql/README.md
+++ b/packages/sql/README.md
@@ -46,12 +46,13 @@ interface SQLResult {
 
 #### Options
 
-| Option           | Type                          | Default      | Description                              |
-| ---------------- | ----------------------------- | ------------ | ---------------------------------------- |
-| `parameterStyle` | `"numbered"` \| `"question"`  | `"numbered"` | Placeholder format                       |
-| `fieldMapper`    | `(field: string) => string`   | `undefined`  | Transform field names to column names    |
-| `valueMapper`    | `(value: unknown) => unknown` | `undefined`  | Transform values before parameterization |
-| `startIndex`     | `number`                      | `1`          | Starting index for numbered placeholders |
+| Option           | Type                          | Default      | Description                                   |
+| ---------------- | ----------------------------- | ------------ | --------------------------------------------- |
+| `parameterStyle` | `"numbered"` \| `"question"`  | `"numbered"` | Placeholder format                            |
+| `fieldMapper`    | `(field: string) => string`   | `undefined`  | Transform field names to column names         |
+| `valueMapper`    | `(value: unknown) => unknown` | `undefined`  | Custom transform for `~` values (see below)   |
+| `likeMode`       | `"contains"` \| `"raw"`       | `"contains"` | How `~` builds its LIKE parameter (see below) |
+| `startIndex`     | `number`                      | `1`          | Starting index for numbered placeholders      |
 
 #### Parameter styles
 
@@ -99,12 +100,38 @@ const { sql, params } = toSQL(ast, {
 // Placeholders start at $3
 ```
 
-### LIKE helpers
+### The contains operator (`~`)
 
-Helper functions for the contains operator (`~`):
+By default `~` means substring-contains, matching @filtron/js. The value is
+wrapped in `%` wildcards and LIKE metacharacters (`%`, `_`, `\`) are escaped
+before parameterization:
+
+```typescript
+const result = parse('name ~ "john"');
+const { sql, params } = toSQL(result.ast);
+// sql: "name LIKE $1"
+// params: ["%john%"]
+
+// Metacharacters in the value match literally
+toSQL(parse('name ~ "100%"').ast).params; // ["%100\\%%"]
+```
+
+Set `likeMode: "raw"` to pass the value through untouched. Wildcards and
+escaping become the caller's responsibility:
+
+```typescript
+const { sql, params } = toSQL(result.ast, { likeMode: "raw" });
+// Query 'name ~ "john%"' produces params: ["john%"]
+```
+
+For prefix or suffix matching, use `valueMapper` with the LIKE helpers.
+`valueMapper` takes precedence over `likeMode`:
 
 ```typescript
 import { toSQL, contains, prefix, suffix, escapeLike } from "@filtron/sql";
+
+const { sql, params } = toSQL(result.ast, { valueMapper: prefix });
+// Query 'name ~ "john"' produces params: ["john%"]
 ```
 
 | Function     | Input   | Output    | Use case             |
@@ -113,15 +140,6 @@ import { toSQL, contains, prefix, suffix, escapeLike } from "@filtron/sql";
 | `prefix`     | `"foo"` | `"foo%"`  | Starts with          |
 | `suffix`     | `"foo"` | `"%foo"`  | Ends with            |
 | `escapeLike` | `"a%b"` | `"a\\%b"` | Escape special chars |
-
-**Usage with valueMapper:**
-
-```typescript
-const { sql, params } = toSQL(ast, {
-	valueMapper: contains,
-});
-// Query "name ~ 'john'" produces params: ["%john%"]
-```
 
 ## Performance
 
@@ -175,6 +193,19 @@ const { sql, params } = toSQL(result.ast);
 ```
 
 Never interpolate user input directly into SQL. Always use the `params` array with your database driver's parameterized query support.
+
+LIKE patterns deserve the same care. The default `likeMode: "contains"` escapes `%`, `_` and `\` so user input cannot smuggle wildcards into the pattern:
+
+```typescript
+// Safe: default likeMode escapes metacharacters
+toSQL(ast); // 'name ~ "100%"' produces params: ["%100\\%%"]
+
+// Unsafe: raw mode passes user input straight into the LIKE pattern
+toSQL(ast, { likeMode: "raw" }); // params: ["100%"] — % acts as a wildcard
+
+// Safe raw usage: escape user input yourself
+toSQL(ast, { valueMapper: (v) => `${escapeLike(String(v))}%` });
+```
 
 ## License
 

--- a/packages/sql/examples/like-patterns.ts
+++ b/packages/sql/examples/like-patterns.ts
@@ -1,32 +1,37 @@
-// Using LIKE patterns with automatic wildcard helpers.
+// LIKE pattern behavior for the contains operator (~).
 // Run with: bun run examples/like-patterns.ts
 
 import { parseOrThrow } from "@filtron/core";
-import { toSQL, contains, prefix, suffix, escapeLike } from "../src/converter";
+import { toSQL, prefix, suffix, escapeLike } from "../src/converter";
 
 const ast = parseOrThrow('name ~ "john"');
 
-// Manual wildcards in the query string
-const manual = toSQL(parseOrThrow('name ~ "%john%"'));
-console.log("Manual:", manual.sql, manual.params);
+// Default: ~ means contains. The value is wrapped in % wildcards
+// with LIKE metacharacters escaped, matching @filtron/js semantics.
+const contains = toSQL(ast);
+console.log("Contains (default):", contains.sql, contains.params);
 // Output: name LIKE $1 ["%john%"]
 
-// Using contains() helper - wraps with % on both sides
-const containsResult = toSQL(ast, { valueMapper: contains });
-console.log("Contains:", containsResult.sql, containsResult.params);
-// Output: name LIKE $1 ["%john%"]
+// Metacharacters in the value are escaped so they match literally
+const escaped = toSQL(parseOrThrow('name ~ "100%"'));
+console.log("Escaped:", escaped.sql, escaped.params);
+// Output: name LIKE $1 ["%100\\%%"]
 
-// Using prefix() helper - for "starts with" queries
+// likeMode "raw" passes the value through untouched;
+// wildcards and escaping are up to the caller
+const raw = toSQL(parseOrThrow('name ~ "john%"'), { likeMode: "raw" });
+console.log("Raw:", raw.sql, raw.params);
+// Output: name LIKE $1 ["john%"]
+
+// valueMapper gives full control and takes precedence over likeMode
 const prefixResult = toSQL(ast, { valueMapper: prefix });
 console.log("Prefix:", prefixResult.sql, prefixResult.params);
 // Output: name LIKE $1 ["john%"]
 
-// Using suffix() helper - for "ends with" queries
 const suffixResult = toSQL(ast, { valueMapper: suffix });
 console.log("Suffix:", suffixResult.sql, suffixResult.params);
 // Output: name LIKE $1 ["%john"]
 
-// escapeLike() prevents LIKE injection when user input contains % or _
-const userInput = "100%_match";
-console.log("Escaped:", escapeLike(userInput));
+// escapeLike() escapes %, _ and \ for custom patterns
+console.log("escapeLike:", escapeLike("100%_match"));
 // Output: 100\%\_match

--- a/packages/sql/src/converter.test.ts
+++ b/packages/sql/src/converter.test.ts
@@ -105,7 +105,7 @@ describe("SQL", () => {
 
 			const result = toSQL(ast);
 			expect(result.sql).toBe("name LIKE $1");
-			expect(result.params).toEqual(["john"]);
+			expect(result.params).toEqual(["%john%"]);
 		});
 
 		test("boolean value", () => {
@@ -562,6 +562,88 @@ describe("SQL", () => {
 	});
 
 	describe("LIKE Value Mapping", () => {
+		test("default likeMode wraps LIKE values for contains matching", () => {
+			const ast: ASTNode = {
+				type: "comparison",
+				field: "name",
+				operator: "~",
+				value: { type: "string", value: "an" },
+			};
+
+			const result = toSQL(ast);
+			expect(result.sql).toBe("name LIKE $1");
+			expect(result.params).toEqual(["%an%"]);
+		});
+
+		test("default likeMode escapes LIKE metacharacters", () => {
+			const ast: ASTNode = {
+				type: "comparison",
+				field: "name",
+				operator: "~",
+				value: { type: "string", value: "100%" },
+			};
+
+			const result = toSQL(ast);
+			expect(result.sql).toBe("name LIKE $1");
+			expect(result.params).toEqual(["%100\\%%"]);
+		});
+
+		test("likeMode 'raw' passes the value through untouched", () => {
+			const ast: ASTNode = {
+				type: "comparison",
+				field: "name",
+				operator: "~",
+				value: { type: "string", value: "100%" },
+			};
+
+			const result = toSQL(ast, { likeMode: "raw" });
+			expect(result.sql).toBe("name LIKE $1");
+			expect(result.params).toEqual(["100%"]);
+		});
+
+		test("likeMode 'contains' can be set explicitly", () => {
+			const ast: ASTNode = {
+				type: "comparison",
+				field: "name",
+				operator: "~",
+				value: { type: "string", value: "john" },
+			};
+
+			const result = toSQL(ast, { likeMode: "contains" });
+			expect(result.sql).toBe("name LIKE $1");
+			expect(result.params).toEqual(["%john%"]);
+		});
+
+		test("valueMapper takes precedence over likeMode", () => {
+			const ast: ASTNode = {
+				type: "comparison",
+				field: "name",
+				operator: "~",
+				value: { type: "string", value: "john" },
+			};
+
+			const result = toSQL(ast, {
+				likeMode: "raw",
+				valueMapper: prefix,
+			});
+
+			expect(result.sql).toBe("name LIKE $1");
+			expect(result.params).toEqual(["john%"]);
+		});
+
+		test("likeMode does not affect the equals operator", () => {
+			const ast: ASTNode = {
+				type: "comparison",
+				field: "name",
+				operator: "=",
+				value: { type: "string", value: "100%" },
+			};
+
+			const result = toSQL(ast);
+			expect(result.sql).toBe("name = $1");
+			expect(result.params).toEqual(["100%"]);
+		});
+
 		test("valueMapper is applied to LIKE operator", () => {
 			const ast: ASTNode = {
 				type: "comparison",
@@ -737,7 +819,7 @@ describe("SQL", () => {
 
 			const result = toSQL(ast, { parameterStyle: "question" });
 			expect(result.sql).toBe("((price <= ? AND name LIKE ?) AND category IN (?, ?))");
-			expect(result.params).toEqual([100, "laptop", "electronics", "computers"]);
+			expect(result.params).toEqual([100, "%laptop%", "electronics", "computers"]);
 		});
 
 		test("nested NOT with complex conditions", () => {

--- a/packages/sql/src/converter.ts
+++ b/packages/sql/src/converter.ts
@@ -47,19 +47,35 @@ export interface SQLOptions {
 
 	/**
 	 * Value mapper for LIKE operator (~)
-	 * Allows adding wildcards or escaping special characters
-	 * Applied to the value before parameterization
-	 * @default (value) => value
+	 * Full custom control over the pattern; applied to the value before
+	 * parameterization. When set, it replaces the `likeMode` behavior
+	 * entirely: no default escaping or wildcard wrapping is applied.
+	 * @default undefined
 	 *
 	 * @example
 	 * ```typescript
-	 * // Auto-wrap LIKE values with wildcards for "contains" search
+	 * // Prefix ("starts with") matching instead of the contains default
 	 * toSQL(ast, {
-	 *   valueMapper: (value) => `%${escapeLike(String(value))}%`
+	 *   valueMapper: (value) => `${escapeLike(String(value))}%`
 	 * })
 	 * ```
 	 */
 	valueMapper?: (value: string | number | boolean) => string | number | boolean;
+
+	/**
+	 * How the `~` operator builds its LIKE parameter value
+	 * - 'contains': wrap the value as `%value%`, escaping LIKE
+	 *   metacharacters (%, _, \) first, matching @filtron/js substring
+	 *   semantics
+	 * - 'raw': pass the value through untouched; wildcards and escaping
+	 *   are the caller's responsibility
+	 *
+	 * Precedence: if `valueMapper` is set it is applied and `likeMode` is
+	 * ignored; otherwise 'raw' passes the value through and 'contains'
+	 * applies the default transform.
+	 * @default 'contains'
+	 */
+	likeMode?: "contains" | "raw";
 
 	/**
 	 * Starting parameter index (for numbered parameters)
@@ -75,7 +91,8 @@ interface GeneratorState {
 	params: unknown[];
 	numbered: boolean;
 	fieldMapper: (field: string) => string;
-	valueMapper: (value: string | number | boolean) => string | number | boolean;
+	/** Resolved `~` value transform: valueMapper, identity (raw), or contains */
+	likeValue: (value: string | number | boolean) => string | number | boolean;
 	paramIndex: number;
 }
 
@@ -111,7 +128,7 @@ export function toSQL(ast: ASTNode, options: SQLOptions = {}): SQLResult {
 		params: [],
 		numbered: options.parameterStyle !== "question",
 		fieldMapper: options.fieldMapper ?? identityField,
-		valueMapper: options.valueMapper ?? identityValue,
+		likeValue: options.valueMapper ?? (options.likeMode === "raw" ? identityValue : contains),
 		paramIndex: options.startIndex ?? 1,
 	};
 
@@ -186,10 +203,10 @@ function generateComparison(node: ComparisonExpression, state: GeneratorState): 
 	const field = state.fieldMapper(node.field);
 	const operator = mapComparisonOperator(node.operator);
 
-	// Apply valueMapper for LIKE operator
+	// Apply the resolved LIKE value transform for the ~ operator
 	let value = extractValue(node.value);
 	if (node.operator === "~") {
-		value = state.valueMapper(value);
+		value = state.likeValue(value);
 	}
 
 	const param = addParameter(value, state);
@@ -335,14 +352,14 @@ export function escapeLike(value: string): string {
 /**
  * Wraps a value with wildcards for "contains" matching
  * Automatically escapes special LIKE characters
+ * This is the default `~` value transform (likeMode 'contains')
  *
  * @param value - The value to wrap
  * @returns Value wrapped with % wildcards
  *
  * @example
  * ```typescript
- * toSQL(ast, { valueMapper: contains })
- * // "foo" becomes "%foo%"
+ * contains("foo") // "%foo%"
  * ```
  */
 export function contains(value: string | number | boolean): string {


### PR DESCRIPTION
### Why

**This is a breaking change**

`name ~ "foo"` meant substring-contains in @filtron/js but a wildcard-free LIKE (exact match) in @filtron/sql — the same query returned different results per backend.

### What

- `~` now produces a `%<escaped>%` LIKE parameter by default, using the existing `escapeLike`/`contains` helpers. Wildcards live only in the parameter value; SQL text is unchanged and fully parameterized.
- New `likeMode?: "contains" | "raw"` option (default `"contains"`); `"raw"` restores the old pass-through behavior.
- Precedence: a supplied `valueMapper` replaces the likeMode behavior entirely (full custom control, no double-escaping). Resolved once per `toSQL` call, so the per-node hot path is unchanged.
- Conformance fixtures updated: the #282 divergence notes are replaced with the unified semantics — this diff is the semantic change on record. js `matches` untouched.
- sql README (options table, a reworked contains section, safe/unsafe LIKE-injection patterns) and the like-patterns example updated.

### Notes

- BREAKING for anyone relying on raw LIKE patterns in queries (e.g. `name ~ "foo%"` now matches the literal `foo%`); migration is `likeMode: "raw"` or a `valueMapper`.
- The elysia-sqlite e2e test used a raw-wildcard query (`name ~ "%a%"`); it now uses `name ~ "a"`, which produces the identical pattern under the new default.
- Bench delta on `~`-free queries is machine variance; the only structural cost is one escaped-string allocation per `~` node.
- Implemented by a Claude Code agent (Claude Fable 5) and independently reviewed and verified before pushing: 362 tests, lint, knip all pass.
- Merge coordination: touches different regions of converter.ts and different fixture entries than the n-ary AST PR; whichever lands second gets a trivial rebase.

Closes: #282