### PR TITLE
feat(core): represent AND/OR chains as n-ary AST nodes

### DIFF
--- a/packages/conformance/src/index.ts
+++ b/packages/conformance/src/index.ts
@@ -281,8 +281,9 @@ export const cases: ConformanceCase[] = [
 		name: "and-chain",
 		query: "verified AND premium AND age > 21",
 		matches: [1, 6, 7],
-		sql: "((verified = $1 AND premium = $2) AND age > $3)",
+		sql: "(verified = $1 AND premium = $2 AND age > $3)",
 		params: [true, true, 21],
+		notes: "Chains are n-ary AST nodes (#283), so a chain renders flat instead of nested pairs.",
 	},
 	{
 		name: "parens-grouping",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -160,8 +160,8 @@ import type { Token, TokenType, StringToken, NumberToken, BooleanToken } from "@
 
 | Node Type      | Fields                       | Example input          |
 | -------------- | ---------------------------- | ---------------------- |
-| `and`          | `left`, `right`              | `a AND b`              |
-| `or`           | `left`, `right`              | `a OR b`               |
+| `and`          | `children`                   | `a AND b`              |
+| `or`           | `children`                   | `a OR b`               |
 | `not`          | `expression`                 | `NOT a`                |
 | `comparison`   | `field`, `operator`, `value` | `age > 18`             |
 | `exists`       | `field`                      | `email?`               |
@@ -169,6 +169,8 @@ import type { Token, TokenType, StringToken, NumberToken, BooleanToken } from "@
 | `oneOf`        | `field`, `values`            | `status : ["a", "b"]`  |
 | `notOneOf`     | `field`, `values`            | `status !: ["a", "b"]` |
 | `range`        | `field`, `min`, `max`        | `age = 18..65`         |
+
+Chains of the same operator are flat: `a AND b AND c` produces a single `and` node with three children, never nested pairs.
 
 **Example output:**
 
@@ -180,18 +182,20 @@ parse('age > 18 AND status = "active"')
   success: true,
   ast: {
     type: "and",
-    left: {
-      type: "comparison",
-      field: "age",
-      operator: ">",
-      value: { type: "number", value: 18 }
-    },
-    right: {
-      type: "comparison",
-      field: "status",
-      operator: "=",
-      value: { type: "string", value: "active" }
-    }
+    children: [
+      {
+        type: "comparison",
+        field: "age",
+        operator: ">",
+        value: { type: "number", value: 18 }
+      },
+      {
+        type: "comparison",
+        field: "status",
+        operator: "=",
+        value: { type: "string", value: "active" }
+      }
+    ]
   }
 }
 ```

--- a/packages/core/examples/ast-inspection.ts
+++ b/packages/core/examples/ast-inspection.ts
@@ -7,7 +7,7 @@ function collectFields(node: ASTNode): string[] {
 	switch (node.type) {
 		case "or":
 		case "and":
-			return [...collectFields(node.left), ...collectFields(node.right)];
+			return node.children.flatMap(collectFields);
 		case "not":
 			return collectFields(node.expression);
 		case "comparison":

--- a/packages/core/src/rd-parser.test.ts
+++ b/packages/core/src/rd-parser.test.ts
@@ -181,15 +181,15 @@ describe("RD Parser", () => {
 		test("AND expression", () => {
 			const ast = parseQuery("a AND b") as AndExpression;
 			expect(ast.type).toBe("and");
-			expect((ast.left as BooleanFieldExpression).field).toBe("a");
-			expect((ast.right as BooleanFieldExpression).field).toBe("b");
+			expect((ast.children[0] as BooleanFieldExpression).field).toBe("a");
+			expect((ast.children[1] as BooleanFieldExpression).field).toBe("b");
 		});
 
 		test("OR expression", () => {
 			const ast = parseQuery("a OR b") as OrExpression;
 			expect(ast.type).toBe("or");
-			expect((ast.left as BooleanFieldExpression).field).toBe("a");
-			expect((ast.right as BooleanFieldExpression).field).toBe("b");
+			expect((ast.children[0] as BooleanFieldExpression).field).toBe("a");
+			expect((ast.children[1] as BooleanFieldExpression).field).toBe("b");
 		});
 
 		test("NOT expression", () => {
@@ -198,17 +198,27 @@ describe("RD Parser", () => {
 			expect((ast.expression as BooleanFieldExpression).field).toBe("suspended");
 		});
 
-		test("multiple AND operators (left-associative)", () => {
+		test("multiple AND operators (flat chain)", () => {
 			const ast = parseQuery("a AND b AND c") as AndExpression;
 			expect(ast.type).toBe("and");
-			expect((ast.left as AndExpression).type).toBe("and");
-			expect((ast.right as BooleanFieldExpression).field).toBe("c");
+			expect(ast.children).toHaveLength(3);
+			expect(ast.children.map((c) => (c as BooleanFieldExpression).field)).toEqual(["a", "b", "c"]);
 		});
 
-		test("multiple OR operators (left-associative)", () => {
+		test("multiple OR operators (flat chain)", () => {
 			const ast = parseQuery("a OR b OR c") as OrExpression;
 			expect(ast.type).toBe("or");
-			expect((ast.left as OrExpression).type).toBe("or");
+			expect(ast.children).toHaveLength(3);
+		});
+
+		test("parenthesized same-type chains are spliced flat", () => {
+			const left = parseQuery("(a AND b) AND c AND (d AND e)") as AndExpression;
+			expect(left.children).toHaveLength(5);
+			expect(left.children.every((c) => c.type === "booleanField")).toBe(true);
+
+			const right = parseQuery("a OR (b OR c)") as OrExpression;
+			expect(right.children).toHaveLength(3);
+			expect(right.children.every((c) => c.type === "booleanField")).toBe(true);
 		});
 	});
 
@@ -216,15 +226,15 @@ describe("RD Parser", () => {
 		test("AND has higher precedence than OR", () => {
 			const ast = parseQuery("a OR b AND c") as OrExpression;
 			expect(ast.type).toBe("or");
-			expect((ast.left as BooleanFieldExpression).field).toBe("a");
-			expect((ast.right as AndExpression).type).toBe("and");
+			expect((ast.children[0] as BooleanFieldExpression).field).toBe("a");
+			expect((ast.children[1] as AndExpression).type).toBe("and");
 		});
 
 		test("parentheses override precedence", () => {
 			const ast = parseQuery("(a OR b) AND c") as AndExpression;
 			expect(ast.type).toBe("and");
-			expect((ast.left as OrExpression).type).toBe("or");
-			expect((ast.right as BooleanFieldExpression).field).toBe("c");
+			expect((ast.children[0] as OrExpression).type).toBe("or");
+			expect((ast.children[1] as BooleanFieldExpression).field).toBe("c");
 		});
 
 		test("nested parentheses", () => {
@@ -235,7 +245,7 @@ describe("RD Parser", () => {
 		test("NOT has highest precedence", () => {
 			const ast = parseQuery("NOT a AND b") as AndExpression;
 			expect(ast.type).toBe("and");
-			expect((ast.left as NotExpression).type).toBe("not");
+			expect((ast.children[0] as NotExpression).type).toBe("not");
 		});
 	});
 
@@ -248,14 +258,14 @@ describe("RD Parser", () => {
 		test("nested conditions with parentheses", () => {
 			const ast = parseQuery("(a AND b) OR (c AND d)") as OrExpression;
 			expect(ast.type).toBe("or");
-			expect((ast.left as AndExpression).type).toBe("and");
-			expect((ast.right as AndExpression).type).toBe("and");
+			expect((ast.children[0] as AndExpression).type).toBe("and");
+			expect((ast.children[1] as AndExpression).type).toBe("and");
 		});
 
 		test("field existence with other conditions", () => {
 			const ast = parseQuery("email? AND verified = true") as AndExpression;
-			expect((ast.left as ExistsExpression).type).toBe("exists");
-			expect((ast.right as ComparisonExpression).type).toBe("comparison");
+			expect((ast.children[0] as ExistsExpression).type).toBe("exists");
+			expect((ast.children[1] as ComparisonExpression).type).toBe("comparison");
 		});
 
 		test("range with other conditions", () => {

--- a/packages/core/src/rd-parser.ts
+++ b/packages/core/src/rd-parser.ts
@@ -107,33 +107,56 @@ class Parser {
 	/**
 	 * Parse OR expression
 	 * OrExpression = AndExpression (OR AndExpression)*
+	 *
+	 * Chains build a single flat node. An operand that is itself an OR
+	 * (only possible through parentheses) is spliced in, so children never
+	 * contain a direct OR child.
 	 */
 	private parseOrExpression(): ASTNode {
-		let left = this.parseAndExpression();
-
-		while (this.check("OR")) {
-			this.advance();
-			const right = this.parseAndExpression();
-			left = { type: "or", left, right };
+		const first = this.parseAndExpression();
+		if (!this.check("OR")) {
+			return first;
 		}
 
-		return left;
+		const children: ASTNode[] = first.type === "or" ? [...first.children] : [first];
+		while (this.check("OR")) {
+			this.advance();
+			const operand = this.parseAndExpression();
+			if (operand.type === "or") {
+				children.push(...operand.children);
+			} else {
+				children.push(operand);
+			}
+		}
+
+		return { type: "or", children };
 	}
 
 	/**
 	 * Parse AND expression
 	 * AndExpression = NotExpression (AND NotExpression)*
+	 *
+	 * Chains build a single flat node, splicing parenthesized AND operands
+	 * like parseOrExpression does.
 	 */
 	private parseAndExpression(): ASTNode {
-		let left = this.parseNotExpression();
-
-		while (this.check("AND")) {
-			this.advance();
-			const right = this.parseNotExpression();
-			left = { type: "and", left, right };
+		const first = this.parseNotExpression();
+		if (!this.check("AND")) {
+			return first;
 		}
 
-		return left;
+		const children: ASTNode[] = first.type === "and" ? [...first.children] : [first];
+		while (this.check("AND")) {
+			this.advance();
+			const operand = this.parseNotExpression();
+			if (operand.type === "and") {
+				children.push(...operand.children);
+			} else {
+				children.push(operand);
+			}
+		}
+
+		return { type: "and", children };
 	}
 
 	/**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -27,21 +27,27 @@ export type Value = StringValue | NumberValue | BooleanValue | IdentifierValue;
 export type ComparisonOperator = "=" | "!=" | "~" | ">" | ">=" | "<" | "<=" | ":";
 
 /**
- * Logical OR expression - combines two expressions with OR
+ * Logical OR expression - combines two or more expressions with OR
+ *
+ * Chains are flat: children always has at least two entries and never
+ * contains another OrExpression. The parser splices nested OR chains
+ * (including parenthesized ones) into a single node.
  */
 export interface OrExpression {
 	type: "or";
-	left: ASTNode;
-	right: ASTNode;
+	children: ASTNode[];
 }
 
 /**
- * Logical AND expression - combines two expressions with AND
+ * Logical AND expression - combines two or more expressions with AND
+ *
+ * Chains are flat: children always has at least two entries and never
+ * contains another AndExpression. The parser splices nested AND chains
+ * (including parenthesized ones) into a single node.
  */
 export interface AndExpression {
 	type: "and";
-	left: ASTNode;
-	right: ASTNode;
+	children: ASTNode[];
 }
 
 /**

--- a/packages/js/src/filter.test.ts
+++ b/packages/js/src/filter.test.ts
@@ -129,18 +129,20 @@ describe("toFilter", () => {
 		test("AND expression", () => {
 			const ast: AndExpression = {
 				type: "and",
-				left: {
-					type: "comparison",
-					field: "age",
-					operator: ">",
-					value: { type: "number", value: 18 },
-				},
-				right: {
-					type: "comparison",
-					field: "status",
-					operator: "=",
-					value: { type: "string", value: "active" },
-				},
+				children: [
+					{
+						type: "comparison",
+						field: "age",
+						operator: ">",
+						value: { type: "number", value: 18 },
+					},
+					{
+						type: "comparison",
+						field: "status",
+						operator: "=",
+						value: { type: "string", value: "active" },
+					},
+				],
 			};
 			const filter = toFilter(ast);
 			expect(filter({ age: 25, status: "active" })).toBe(true);
@@ -151,18 +153,20 @@ describe("toFilter", () => {
 		test("OR expression", () => {
 			const ast: OrExpression = {
 				type: "or",
-				left: {
-					type: "comparison",
-					field: "role",
-					operator: "=",
-					value: { type: "string", value: "admin" },
-				},
-				right: {
-					type: "comparison",
-					field: "role",
-					operator: "=",
-					value: { type: "string", value: "moderator" },
-				},
+				children: [
+					{
+						type: "comparison",
+						field: "role",
+						operator: "=",
+						value: { type: "string", value: "admin" },
+					},
+					{
+						type: "comparison",
+						field: "role",
+						operator: "=",
+						value: { type: "string", value: "moderator" },
+					},
+				],
 			};
 			const filter = toFilter(ast);
 			expect(filter({ role: "admin" })).toBe(true);
@@ -495,18 +499,20 @@ describe("toFilter", () => {
 		test("maps multiple fields", () => {
 			const ast: AndExpression = {
 				type: "and",
-				left: {
-					type: "comparison",
-					field: "first_name",
-					operator: "=",
-					value: { type: "string", value: "John" },
-				},
-				right: {
-					type: "comparison",
-					field: "last_name",
-					operator: "=",
-					value: { type: "string", value: "Doe" },
-				},
+				children: [
+					{
+						type: "comparison",
+						field: "first_name",
+						operator: "=",
+						value: { type: "string", value: "John" },
+					},
+					{
+						type: "comparison",
+						field: "last_name",
+						operator: "=",
+						value: { type: "string", value: "Doe" },
+					},
+				],
 			};
 			const filter = toFilter(ast, {
 				fieldMapping: {
@@ -776,15 +782,7 @@ describe("toFilter", () => {
 			type: "and" | "or",
 			leaves: ComparisonExpression[],
 		): AndExpression | OrExpression => {
-			let node: AndExpression | OrExpression = {
-				type,
-				left: leaves[0],
-				right: leaves[1],
-			} as AndExpression;
-			for (let i = 2; i < leaves.length; i++) {
-				node = { type, left: node, right: leaves[i] } as AndExpression;
-			}
-			return node;
+			return { type, children: leaves } as AndExpression;
 		};
 
 		const leaves = (n: number) => Array.from({ length: n }, (_, i) => comparison(`f${i}`, i));
@@ -806,14 +804,14 @@ describe("toFilter", () => {
 			expect(filter(Object.assign(none(), { [`f${n - 1}`]: n - 1 }))).toBe(true);
 		});
 
-		test("right-nested chains flatten and preserve semantics", () => {
+		test("hand-built nested same-type nodes still evaluate correctly", () => {
+			// The parser never produces this shape, but adapters accept it
 			const [a, b, c] = leaves(3);
-			const rightNested: AndExpression = {
+			const nested: AndExpression = {
 				type: "and",
-				left: a,
-				right: { type: "and", left: b, right: c },
+				children: [a, { type: "and", children: [b, c] }],
 			};
-			const filter = toFilter(rightNested);
+			const filter = toFilter(nested);
 			expect(filter(match(3))).toBe(true);
 			expect(filter(Object.assign(match(3), { f1: -1 }))).toBe(false);
 		});

--- a/packages/js/src/filter.ts
+++ b/packages/js/src/filter.ts
@@ -177,66 +177,37 @@ function generateFilter(
 }
 
 /**
- * Collects predicates from a chain of OR nodes (left-to-right order)
- * Flattening avoids one closure call per binary node when evaluating chains
- */
-function collectOr(
-	node: ASTNode,
-	predicates: FilterPredicate<Record<string, unknown>>[],
-	state: GeneratorState,
-): void {
-	if (node.type === "or") {
-		collectOr(node.left, predicates, state);
-		collectOr(node.right, predicates, state);
-	} else {
-		predicates.push(generateFilter(node, state));
-	}
-}
-
-/**
- * Collects predicates from a chain of AND nodes (left-to-right order)
- */
-function collectAnd(
-	node: ASTNode,
-	predicates: FilterPredicate<Record<string, unknown>>[],
-	state: GeneratorState,
-): void {
-	if (node.type === "and") {
-		collectAnd(node.left, predicates, state);
-		collectAnd(node.right, predicates, state);
-	} else {
-		predicates.push(generateFilter(node, state));
-	}
-}
-
-/**
  * Generates predicate for OR expression
- * Flattens OR chains and specializes common arities
+ * The parser guarantees flat chains of two or more children; common
+ * arities compile to direct short-circuit chains
  */
 function generateOr(
 	node: OrExpression,
 	state: GeneratorState,
 ): FilterPredicate<Record<string, unknown>> {
-	// Fast path: plain binary OR needs no chain collection
-	if (node.left.type !== "or" && node.right.type !== "or") {
-		const a = generateFilter(node.left, state);
-		const b = generateFilter(node.right, state);
+	const children = node.children;
+	const len = children.length;
+
+	if (len === 2) {
+		const a = generateFilter(children[0], state);
+		const b = generateFilter(children[1], state);
 		return (item) => a(item) || b(item);
 	}
-
-	// A chain reaching here always flattens to three or more predicates
-	const predicates: FilterPredicate<Record<string, unknown>>[] = [];
-	collectOr(node, predicates, state);
-	const len = predicates.length;
-
 	if (len === 3) {
-		const [a, b, c] = predicates;
+		const a = generateFilter(children[0], state);
+		const b = generateFilter(children[1], state);
+		const c = generateFilter(children[2], state);
 		return (item) => a(item) || b(item) || c(item);
 	}
 	if (len === 4) {
-		const [a, b, c, d] = predicates;
+		const a = generateFilter(children[0], state);
+		const b = generateFilter(children[1], state);
+		const c = generateFilter(children[2], state);
+		const d = generateFilter(children[3], state);
 		return (item) => a(item) || b(item) || c(item) || d(item);
 	}
+
+	const predicates = children.map((child) => generateFilter(child, state));
 	return (item) => {
 		for (let i = 0; i < len; i++) {
 			if (predicates[i](item)) return true;
@@ -247,32 +218,36 @@ function generateOr(
 
 /**
  * Generates predicate for AND expression
- * Flattens AND chains and specializes common arities
+ * The parser guarantees flat chains of two or more children; common
+ * arities compile to direct short-circuit chains
  */
 function generateAnd(
 	node: AndExpression,
 	state: GeneratorState,
 ): FilterPredicate<Record<string, unknown>> {
-	// Fast path: plain binary AND needs no chain collection
-	if (node.left.type !== "and" && node.right.type !== "and") {
-		const a = generateFilter(node.left, state);
-		const b = generateFilter(node.right, state);
+	const children = node.children;
+	const len = children.length;
+
+	if (len === 2) {
+		const a = generateFilter(children[0], state);
+		const b = generateFilter(children[1], state);
 		return (item) => a(item) && b(item);
 	}
-
-	// A chain reaching here always flattens to three or more predicates
-	const predicates: FilterPredicate<Record<string, unknown>>[] = [];
-	collectAnd(node, predicates, state);
-	const len = predicates.length;
-
 	if (len === 3) {
-		const [a, b, c] = predicates;
+		const a = generateFilter(children[0], state);
+		const b = generateFilter(children[1], state);
+		const c = generateFilter(children[2], state);
 		return (item) => a(item) && b(item) && c(item);
 	}
 	if (len === 4) {
-		const [a, b, c, d] = predicates;
+		const a = generateFilter(children[0], state);
+		const b = generateFilter(children[1], state);
+		const c = generateFilter(children[2], state);
+		const d = generateFilter(children[3], state);
 		return (item) => a(item) && b(item) && c(item) && d(item);
 	}
+
+	const predicates = children.map((child) => generateFilter(child, state));
 	return (item) => {
 		for (let i = 0; i < len; i++) {
 			if (!predicates[i](item)) return false;

--- a/packages/sql/src/converter.test.ts
+++ b/packages/sql/src/converter.test.ts
@@ -139,18 +139,20 @@ describe("SQL", () => {
 		test("AND expression", () => {
 			const ast: ASTNode = {
 				type: "and",
-				left: {
-					type: "comparison",
-					field: "age",
-					operator: ">",
-					value: { type: "number", value: 18 },
-				},
-				right: {
-					type: "comparison",
-					field: "status",
-					operator: "=",
-					value: { type: "string", value: "active" },
-				},
+				children: [
+					{
+						type: "comparison",
+						field: "age",
+						operator: ">",
+						value: { type: "number", value: 18 },
+					},
+					{
+						type: "comparison",
+						field: "status",
+						operator: "=",
+						value: { type: "string", value: "active" },
+					},
+				],
 			};
 
 			const result = toSQL(ast);
@@ -158,21 +160,43 @@ describe("SQL", () => {
 			expect(result.params).toEqual([18, "active"]);
 		});
 
+		test("AND chain renders flat", () => {
+			const ast: ASTNode = {
+				type: "and",
+				children: [
+					{ type: "booleanField", field: "verified" },
+					{ type: "booleanField", field: "premium" },
+					{
+						type: "comparison",
+						field: "age",
+						operator: ">",
+						value: { type: "number", value: 21 },
+					},
+				],
+			};
+
+			const result = toSQL(ast);
+			expect(result.sql).toBe("(verified = $1 AND premium = $2 AND age > $3)");
+			expect(result.params).toEqual([true, true, 21]);
+		});
+
 		test("OR expression", () => {
 			const ast: ASTNode = {
 				type: "or",
-				left: {
-					type: "comparison",
-					field: "role",
-					operator: "=",
-					value: { type: "string", value: "admin" },
-				},
-				right: {
-					type: "comparison",
-					field: "role",
-					operator: "=",
-					value: { type: "string", value: "moderator" },
-				},
+				children: [
+					{
+						type: "comparison",
+						field: "role",
+						operator: "=",
+						value: { type: "string", value: "admin" },
+					},
+					{
+						type: "comparison",
+						field: "role",
+						operator: "=",
+						value: { type: "string", value: "moderator" },
+					},
+				],
 			};
 
 			const result = toSQL(ast);
@@ -199,27 +223,31 @@ describe("SQL", () => {
 		test("complex nested expression", () => {
 			const ast: ASTNode = {
 				type: "and",
-				left: {
-					type: "or",
-					left: {
-						type: "comparison",
-						field: "role",
-						operator: "=",
-						value: { type: "string", value: "admin" },
+				children: [
+					{
+						type: "or",
+						children: [
+							{
+								type: "comparison",
+								field: "role",
+								operator: "=",
+								value: { type: "string", value: "admin" },
+							},
+							{
+								type: "comparison",
+								field: "role",
+								operator: "=",
+								value: { type: "string", value: "moderator" },
+							},
+						],
 					},
-					right: {
+					{
 						type: "comparison",
-						field: "role",
+						field: "status",
 						operator: "=",
-						value: { type: "string", value: "moderator" },
+						value: { type: "string", value: "active" },
 					},
-				},
-				right: {
-					type: "comparison",
-					field: "status",
-					operator: "=",
-					value: { type: "string", value: "active" },
-				},
+				],
 			};
 
 			const result = toSQL(ast);
@@ -409,14 +437,16 @@ describe("SQL", () => {
 		test("boolean field with AND", () => {
 			const ast: ASTNode = {
 				type: "and",
-				left: {
-					type: "booleanField",
-					field: "verified",
-				},
-				right: {
-					type: "booleanField",
-					field: "premium",
-				},
+				children: [
+					{
+						type: "booleanField",
+						field: "verified",
+					},
+					{
+						type: "booleanField",
+						field: "premium",
+					},
+				],
 			};
 
 			const result = toSQL(ast);
@@ -429,18 +459,20 @@ describe("SQL", () => {
 		test("numbered parameters (PostgreSQL style)", () => {
 			const ast: ASTNode = {
 				type: "and",
-				left: {
-					type: "comparison",
-					field: "age",
-					operator: ">",
-					value: { type: "number", value: 18 },
-				},
-				right: {
-					type: "comparison",
-					field: "status",
-					operator: "=",
-					value: { type: "string", value: "active" },
-				},
+				children: [
+					{
+						type: "comparison",
+						field: "age",
+						operator: ">",
+						value: { type: "number", value: 18 },
+					},
+					{
+						type: "comparison",
+						field: "status",
+						operator: "=",
+						value: { type: "string", value: "active" },
+					},
+				],
 			};
 
 			const result = toSQL(ast, { parameterStyle: "numbered" });
@@ -451,18 +483,20 @@ describe("SQL", () => {
 		test("question mark parameters (MySQL/SQLite style)", () => {
 			const ast: ASTNode = {
 				type: "and",
-				left: {
-					type: "comparison",
-					field: "age",
-					operator: ">",
-					value: { type: "number", value: 18 },
-				},
-				right: {
-					type: "comparison",
-					field: "status",
-					operator: "=",
-					value: { type: "string", value: "active" },
-				},
+				children: [
+					{
+						type: "comparison",
+						field: "age",
+						operator: ">",
+						value: { type: "number", value: 18 },
+					},
+					{
+						type: "comparison",
+						field: "status",
+						operator: "=",
+						value: { type: "string", value: "active" },
+					},
+				],
 			};
 
 			const result = toSQL(ast, { parameterStyle: "question" });
@@ -536,20 +570,22 @@ describe("SQL", () => {
 		test("field mapper with complex nested expression", () => {
 			const ast: ASTNode = {
 				type: "and",
-				left: {
-					type: "comparison",
-					field: "age",
-					operator: ">",
-					value: { type: "number", value: 18 },
-				},
-				right: {
-					type: "oneOf",
-					field: "status",
-					values: [
-						{ type: "string", value: "active" },
-						{ type: "string", value: "pending" },
-					],
-				},
+				children: [
+					{
+						type: "comparison",
+						field: "age",
+						operator: ">",
+						value: { type: "number", value: 18 },
+					},
+					{
+						type: "oneOf",
+						field: "status",
+						values: [
+							{ type: "string", value: "active" },
+							{ type: "string", value: "pending" },
+						],
+					},
+				],
 			};
 
 			const result = toSQL(ast, {
@@ -727,18 +763,20 @@ describe("SQL", () => {
 		test("valueMapper with multiple LIKE conditions", () => {
 			const ast: ASTNode = {
 				type: "and",
-				left: {
-					type: "comparison",
-					field: "firstName",
-					operator: "~",
-					value: { type: "string", value: "john" },
-				},
-				right: {
-					type: "comparison",
-					field: "lastName",
-					operator: "~",
-					value: { type: "string", value: "doe" },
-				},
+				children: [
+					{
+						type: "comparison",
+						field: "firstName",
+						operator: "~",
+						value: { type: "string", value: "john" },
+					},
+					{
+						type: "comparison",
+						field: "lastName",
+						operator: "~",
+						value: { type: "string", value: "doe" },
+					},
+				],
 			};
 
 			const result = toSQL(ast, {
@@ -752,99 +790,104 @@ describe("SQL", () => {
 
 	describe("Complex Real-world Queries", () => {
 		test("user filtering query", () => {
+			// age >= 18 AND verified AND (role = "admin" OR role = "moderator")
 			const ast: ASTNode = {
 				type: "and",
-				left: {
-					type: "and",
-					left: {
+				children: [
+					{
 						type: "comparison",
 						field: "age",
 						operator: ">=",
 						value: { type: "number", value: 18 },
 					},
-					right: {
+					{
 						type: "booleanField",
 						field: "verified",
 					},
-				},
-				right: {
-					type: "or",
-					left: {
-						type: "comparison",
-						field: "role",
-						operator: "=",
-						value: { type: "string", value: "admin" },
+					{
+						type: "or",
+						children: [
+							{
+								type: "comparison",
+								field: "role",
+								operator: "=",
+								value: { type: "string", value: "admin" },
+							},
+							{
+								type: "comparison",
+								field: "role",
+								operator: "=",
+								value: { type: "string", value: "moderator" },
+							},
+						],
 					},
-					right: {
-						type: "comparison",
-						field: "role",
-						operator: "=",
-						value: { type: "string", value: "moderator" },
-					},
-				},
+				],
 			};
 
 			const result = toSQL(ast);
-			expect(result.sql).toBe("((age >= $1 AND verified = $2) AND (role = $3 OR role = $4))");
+			expect(result.sql).toBe("(age >= $1 AND verified = $2 AND (role = $3 OR role = $4))");
 			expect(result.params).toEqual([18, true, "admin", "moderator"]);
 		});
 
 		test("product search query", () => {
 			const ast: ASTNode = {
 				type: "and",
-				left: {
-					type: "and",
-					left: {
+				children: [
+					{
 						type: "comparison",
 						field: "price",
 						operator: "<=",
 						value: { type: "number", value: 100 },
 					},
-					right: {
+					{
 						type: "comparison",
 						field: "name",
 						operator: "~",
 						value: { type: "string", value: "laptop" },
 					},
-				},
-				right: {
-					type: "oneOf",
-					field: "category",
-					values: [
-						{ type: "string", value: "electronics" },
-						{ type: "string", value: "computers" },
-					],
-				},
+					{
+						type: "oneOf",
+						field: "category",
+						values: [
+							{ type: "string", value: "electronics" },
+							{ type: "string", value: "computers" },
+						],
+					},
+				],
 			};
 
 			const result = toSQL(ast, { parameterStyle: "question" });
-			expect(result.sql).toBe("((price <= ? AND name LIKE ?) AND category IN (?, ?))");
+			expect(result.sql).toBe("(price <= ? AND name LIKE ? AND category IN (?, ?))");
 			expect(result.params).toEqual([100, "%laptop%", "electronics", "computers"]);
 		});
 
 		test("nested NOT with complex conditions", () => {
 			const ast: ASTNode = {
 				type: "and",
-				left: {
-					type: "comparison",
-					field: "status",
-					operator: "=",
-					value: { type: "string", value: "active" },
-				},
-				right: {
-					type: "not",
-					expression: {
-						type: "or",
-						left: {
-							type: "booleanField",
-							field: "suspended",
-						},
-						right: {
-							type: "booleanField",
-							field: "deleted",
+				children: [
+					{
+						type: "comparison",
+						field: "status",
+						operator: "=",
+						value: { type: "string", value: "active" },
+					},
+					{
+						type: "not",
+						expression: {
+							type: "or",
+							children: [
+								{
+									type: "booleanField",
+									field: "suspended",
+								},
+								{
+									type: "booleanField",
+									field: "deleted",
+								},
+							],
 						},
 					},
-				},
+				],
 			};
 
 			const result = toSQL(ast);

--- a/packages/sql/src/converter.ts
+++ b/packages/sql/src/converter.ts
@@ -172,20 +172,26 @@ function generateSQL(node: ASTNode, state: GeneratorState): string {
 
 /**
  * Generates SQL for OR expression
+ * The parser guarantees flat chains of two or more children
  */
 function generateOr(node: OrExpression, state: GeneratorState): string {
-	const left = generateSQL(node.left, state);
-	const right = generateSQL(node.right, state);
-	return `(${left} OR ${right})`;
+	let sql = generateSQL(node.children[0], state);
+	for (let i = 1; i < node.children.length; i++) {
+		sql += " OR " + generateSQL(node.children[i], state);
+	}
+	return `(${sql})`;
 }
 
 /**
  * Generates SQL for AND expression
+ * The parser guarantees flat chains of two or more children
  */
 function generateAnd(node: AndExpression, state: GeneratorState): string {
-	const left = generateSQL(node.left, state);
-	const right = generateSQL(node.right, state);
-	return `(${left} AND ${right})`;
+	let sql = generateSQL(node.children[0], state);
+	for (let i = 1; i < node.children.length; i++) {
+		sql += " AND " + generateSQL(node.children[i], state);
+	}
+	return `(${sql})`;
 }
 
 /**


### PR DESCRIPTION
**This is a breaking change**

### Why

Binary left/right nesting made every consumer re-flatten chains: `@filtron/js` collected chains at compile time, the upcoming walker, negation model and precedence printer would each re-derive the same structure.

### What

- `OrExpression`/`AndExpression` carry `children: ASTNode[]` (always 2+, never a direct child of the same type). The parser builds flat chains and splices same-type operands arriving through parentheses.
- `@filtron/js` drops its chain-collection pass; arity specializations read children directly.
- `@filtron/sql` renders chains flat: `(a AND b AND c)` instead of `((a AND b) AND c)` — conformance fixture updated to record the output change.
- AST docs in the core README updated; the ast-inspection example now uses `children.flatMap`.

### Notes

- BREAKING for anyone walking ASTs: handle `children` instead of `left`/`right`.
- Adapters still evaluate hand-built nested same-type nodes correctly (covered by a test); the parser just never produces them.

Closes: #283
Refs: #267
Refs: #284
Refs: #264