### PR TITLE
chore(core): unify parse errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ const result = parse('age > 18 AND status = "active"');
 if (result.success) {
 	// result.ast contains the parsed query
 } else {
-	// result.error contains what went wrong
+	// result.message contains what went wrong
 }
 ```
 

--- a/examples/elysia-sqlite/src/index.ts
+++ b/examples/elysia-sqlite/src/index.ts
@@ -43,7 +43,6 @@ export const app = new Elysia()
 					success: false,
 					error: "Invalid filter query",
 					message: parseResult.message,
-					details: parseResult.error,
 					hint: 'Example: ?filter=age > 30 or ?filter=status = "active"',
 				};
 			}

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -39,7 +39,7 @@ const result = parse('age > 18 AND status = "active"');
 if (result.success) {
 	console.log(result.ast);
 } else {
-	console.error(result.error);
+	console.error(result.message);
 }
 ```
 
@@ -100,14 +100,14 @@ const result = parse("age > 18");
 if (result.success) {
 	result.ast; // ASTNode
 } else {
-	result.error; // string - error message
+	result.message; // string - error message
 	result.position; // number - position in input where error occurred
 }
 ```
 
 ### `parseOrThrow(input: string): ASTNode`
 
-Parses a filter expression, throwing `FiltronParseError` on invalid input.
+Parses a filter expression, throwing `FiltronParseError` on invalid input. The same error class is used for all parse failures, whether they originate in the lexer or the parser.
 
 ```typescript
 import { parseOrThrow, FiltronParseError } from "@filtron/core";
@@ -128,7 +128,7 @@ All AST types are exported for building custom consumers:
 
 ```typescript
 import {
-	FiltronParseError, // Error class thrown by parseOrThrow
+	FiltronParseError, // Error class for all parse failures
 	type ParseResult,
 	type ASTNode,
 	type AndExpression,
@@ -152,7 +152,7 @@ import {
 The Lexer types are also available if you want to use them for syntax highlighting or other purposes:
 
 ```typescript
-import { Lexer, LexerError } from "@filtron/core";
+import { Lexer } from "@filtron/core";
 import type { Token, TokenType, StringToken, NumberToken, BooleanToken } from "@filtron/core";
 ```
 

--- a/packages/core/examples/error-handling.ts
+++ b/packages/core/examples/error-handling.ts
@@ -3,11 +3,11 @@
 
 import { parse, parseOrThrow, FiltronParseError } from "../src/index";
 
-// Using parse() - returns a result object with success/error
+// Using parse() - returns a result object with success/message
 const result = parse("invalid === query");
 
 if (!result.success) {
-	console.log("Parse failed:", result.error);
+	console.log("Parse failed:", result.message);
 	if (result.position !== undefined) {
 		console.log("Error position:", result.position);
 	}

--- a/packages/core/examples/simple.ts
+++ b/packages/core/examples/simple.ts
@@ -8,5 +8,5 @@ const result = parse('status = "active" AND age >= 18');
 if (result.success) {
 	console.log(result.ast);
 } else {
-	console.error(result.error);
+	console.error(result.message);
 }

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,0 +1,17 @@
+/**
+ * Errors thrown by the Filtron parser
+ */
+
+/**
+ * Error thrown when parsing a Filtron query fails.
+ * Includes the position in the query where the error occurred.
+ */
+export class FiltronParseError extends Error {
+	constructor(
+		message: string,
+		public position?: number,
+	) {
+		super(message);
+		this.name = "FiltronParseError";
+	}
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,10 +14,10 @@
 
 // Parser functions
 export { parse, parseOrThrow, FiltronParseError } from "./parser";
-export type { ParseResult, ParseSuccess, ParseError } from "./parser";
+export type { ParseResult, ParseSuccess, ParseFailure } from "./parser";
 
 // Lexer for tokenization
-export { Lexer, LexerError } from "./lexer";
+export { Lexer } from "./lexer";
 export type {
 	Token,
 	TokenType,

--- a/packages/core/src/lexer.test.ts
+++ b/packages/core/src/lexer.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { Lexer, LexerError, type Token, type TokenType } from "./lexer";
+import { FiltronParseError } from "./errors";
+import { Lexer, type Token, type TokenType } from "./lexer";
 
 /**
  * Helper to tokenize a complete input string
@@ -211,12 +212,12 @@ describe("Lexer", () => {
 
 		test("unterminated string throws error", () => {
 			const lexer = new Lexer('"unterminated');
-			expect(() => lexer.next()).toThrow(LexerError);
+			expect(() => lexer.next()).toThrow(FiltronParseError);
 			try {
 				const lexer2 = new Lexer('"unterminated');
 				lexer2.next();
 			} catch (error) {
-				expect(error).toBeInstanceOf(LexerError);
+				expect(error).toBeInstanceOf(FiltronParseError);
 				expect((error as Error).message).toBe("Unterminated string literal");
 			}
 		});
@@ -297,7 +298,7 @@ describe("Lexer", () => {
 	describe("Error Handling", () => {
 		test("unexpected character", () => {
 			const lexer = new Lexer("@");
-			expect(() => lexer.next()).toThrow(LexerError);
+			expect(() => lexer.next()).toThrow(FiltronParseError);
 			expect(() => lexer.next()).toThrow("Unexpected character: '@'");
 		});
 
@@ -308,8 +309,8 @@ describe("Lexer", () => {
 				lexer.next();
 				expect(true).toBe(false); // should not reach here
 			} catch (error) {
-				expect(error).toBeInstanceOf(LexerError);
-				expect((error as LexerError).position).toBe(6);
+				expect(error).toBeInstanceOf(FiltronParseError);
+				expect((error as FiltronParseError).position).toBe(6);
 			}
 		});
 	});

--- a/packages/core/src/lexer.ts
+++ b/packages/core/src/lexer.ts
@@ -2,6 +2,8 @@
  * A Lexer for the Filtron query language
  */
 
+import { FiltronParseError } from "./errors";
+
 /**
  * Token types produced by the lexer
  */
@@ -173,19 +175,6 @@ const CHAR_CLASS: Uint8Array = (() => {
 })();
 
 /**
- * Lexer error with position information
- */
-export class LexerError extends Error {
-	constructor(
-		message: string,
-		public position: number,
-	) {
-		super(message);
-		this.name = "LexerError";
-	}
-}
-
-/**
  * Lexer for tokenizing Filtron query strings
  */
 export class Lexer {
@@ -276,7 +265,7 @@ export class Lexer {
 			}
 		}
 
-		throw new LexerError("Unterminated string literal", start);
+		throw new FiltronParseError("Unterminated string literal", start);
 	}
 
 	/**
@@ -513,7 +502,7 @@ export class Lexer {
 					this.pos = pos + 2;
 					return { type: "NOT_COLON", start: pos, end: pos + 2 };
 				}
-				throw new LexerError(`Unexpected character: '${input[pos]}'`, pos);
+				throw new FiltronParseError(`Unexpected character: '${input[pos]}'`, pos);
 			}
 			case CLS_GT:
 				if (pos + 1 < length && input.charCodeAt(pos + 1) === C.Equals) {
@@ -541,10 +530,10 @@ export class Lexer {
 				if (nextCode >= C.Zero && nextCode <= C.Nine) {
 					return this.readNumber();
 				}
-				throw new LexerError(`Unexpected character: '${input[pos]}'`, pos);
+				throw new FiltronParseError(`Unexpected character: '${input[pos]}'`, pos);
 			}
 			default:
-				throw new LexerError(`Unexpected character: '${input[pos]}'`, pos);
+				throw new FiltronParseError(`Unexpected character: '${input[pos]}'`, pos);
 		}
 	}
 }

--- a/packages/core/src/parser.test.ts
+++ b/packages/core/src/parser.test.ts
@@ -24,9 +24,8 @@ describe("Parser API", () => {
 			const result = parse("age >");
 			expect(result.success).toBe(false);
 			if (!result.success) {
-				expect(result.error).toBeDefined();
 				expect(result.message).toBeDefined();
-				expect(typeof result.error).toBe("string");
+				expect(typeof result.message).toBe("string");
 				expect(result.position).toBe(5);
 			}
 		});
@@ -35,7 +34,7 @@ describe("Parser API", () => {
 			const result = parse("");
 			expect(result.success).toBe(false);
 			if (!result.success) {
-				expect(result.error).toContain("Empty query");
+				expect(result.message).toContain("Empty query");
 				expect(result.position).toBe(0);
 			}
 		});
@@ -44,7 +43,7 @@ describe("Parser API", () => {
 			const result = parse('"unterminated string');
 			expect(result.success).toBe(false);
 			if (!result.success) {
-				expect(result.error).toContain("Unterminated string literal");
+				expect(result.message).toContain("Unterminated string literal");
 				expect(result.position).toBe(0);
 			}
 		});
@@ -53,7 +52,7 @@ describe("Parser API", () => {
 			const result = parse("(age > 18");
 			expect(result.success).toBe(false);
 			if (!result.success) {
-				expect(result.error).toBeDefined();
+				expect(result.message).toBeDefined();
 				expect(result.position).toBe(9);
 			}
 		});
@@ -62,7 +61,7 @@ describe("Parser API", () => {
 			const result = parse("age @ 18");
 			expect(result.success).toBe(false);
 			if (!result.success) {
-				expect(result.error).toContain("Unexpected character");
+				expect(result.message).toContain("Unexpected character");
 				expect(result.position).toBe(4);
 			}
 		});
@@ -83,11 +82,20 @@ describe("Parser API", () => {
 			expect(result.success).toBe(true);
 		});
 
-		test("preserves error messages from ParseError", () => {
+		test("preserves error messages from parser errors", () => {
 			const result = parse("status : []");
 			expect(result.success).toBe(false);
 			if (!result.success) {
-				expect(result.error).toContain("Array cannot be empty");
+				expect(result.message).toContain("Array cannot be empty");
+			}
+		});
+
+		test("returns error result without position for non-parse errors", () => {
+			const result = parse(null as unknown as string);
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(typeof result.message).toBe("string");
+				expect(result.position).toBeUndefined();
 			}
 		});
 	});
@@ -106,7 +114,7 @@ describe("Parser API", () => {
 
 		test("throws FiltronParseError on parse failure", () => {
 			expect(() => parseOrThrow("age >")).toThrow(FiltronParseError);
-			expect(() => parseOrThrow("age >")).toThrow("Failed to parse Filtron query");
+			expect(() => parseOrThrow("age >")).toThrow("Expected value");
 		});
 
 		test("throws FiltronParseError for empty query with position", () => {
@@ -144,9 +152,18 @@ describe("Parser API", () => {
 				expect(true).toBe(false); // Should not reach here
 			} catch (error) {
 				expect(error).toBeInstanceOf(FiltronParseError);
-				expect((error as FiltronParseError).message).toContain("Failed to parse Filtron query");
 				expect((error as FiltronParseError).message).toContain("Array cannot be empty");
 				expect((error as FiltronParseError).position).toBeDefined();
+			}
+		});
+
+		test("wraps non-parse errors in FiltronParseError without position", () => {
+			try {
+				parseOrThrow(null as unknown as string);
+				expect(true).toBe(false); // Should not reach here
+			} catch (error) {
+				expect(error).toBeInstanceOf(FiltronParseError);
+				expect((error as FiltronParseError).position).toBeUndefined();
 			}
 		});
 	});

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -2,23 +2,11 @@
  * The Filtron parser public API
  */
 
-import { LexerError } from "./lexer";
-import { parseQuery, ParseError as RDParseError } from "./rd-parser";
+import { FiltronParseError } from "./errors";
+import { parseQuery } from "./rd-parser";
 import type { ASTNode } from "./types";
 
-/**
- * Error thrown by parseOrThrow when parsing fails.
- * Includes the position in the query where the error occurred.
- */
-export class FiltronParseError extends Error {
-	constructor(
-		message: string,
-		public position?: number,
-	) {
-		super(message);
-		this.name = "FiltronParseError";
-	}
-}
+export { FiltronParseError } from "./errors";
 
 /**
  * Result of a successful parse operation
@@ -31,9 +19,8 @@ export interface ParseSuccess {
 /**
  * Result of a failed parse operation
  */
-export interface ParseError {
+export interface ParseFailure {
 	success: false;
-	error: string;
 	message: string;
 	position?: number;
 }
@@ -41,7 +28,7 @@ export interface ParseError {
 /**
  * The generic parse result
  */
-export type ParseResult = ParseSuccess | ParseError;
+export type ParseResult = ParseSuccess | ParseFailure;
 
 /**
  * Parses a Filtron query string into an Abstract Syntax Tree (AST).
@@ -55,7 +42,7 @@ export type ParseResult = ParseSuccess | ParseError;
  * if (result.success) {
  *   console.log(result.ast);
  * } else {
- *   console.error(result.error);
+ *   console.error(result.message);
  * }
  * ```
  */
@@ -67,23 +54,17 @@ export const parse = (query: string): ParseResult => {
 			ast,
 		};
 	} catch (error) {
-		let message: string;
-		let position: number | undefined;
-
-		if (error instanceof RDParseError || error instanceof LexerError) {
-			message = error.message;
-			position = error.position;
-		} else if (error instanceof Error) {
-			message = error.message;
-		} else {
-			message = String(error);
+		if (error instanceof FiltronParseError) {
+			return {
+				success: false,
+				message: error.message,
+				position: error.position,
+			};
 		}
 
 		return {
 			success: false,
-			error: message,
-			message,
-			position,
+			message: error instanceof Error ? error.message : String(error),
 		};
 	}
 };
@@ -109,11 +90,13 @@ export const parse = (query: string): ParseResult => {
  * ```
  */
 export const parseOrThrow = (query: string): ASTNode => {
-	const result = parse(query);
+	try {
+		return parseQuery(query);
+	} catch (error) {
+		if (error instanceof FiltronParseError) {
+			throw error;
+		}
 
-	if (result.success) {
-		return result.ast;
+		throw new FiltronParseError(error instanceof Error ? error.message : String(error));
 	}
-
-	throw new FiltronParseError(`Failed to parse Filtron query: ${result.error}`, result.position);
 };

--- a/packages/core/src/rd-parser.test.ts
+++ b/packages/core/src/rd-parser.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "bun:test";
-import { parseQuery, ParseError } from "./rd-parser";
+import { FiltronParseError } from "./errors";
+import { parseQuery } from "./rd-parser";
 import type {
 	ComparisonExpression,
 	OrExpression,
@@ -271,42 +272,42 @@ describe("RD Parser", () => {
 
 	describe("Error Handling", () => {
 		test("empty query throws error", () => {
-			expect(() => parseQuery("")).toThrow(ParseError);
+			expect(() => parseQuery("")).toThrow(FiltronParseError);
 			expect(() => parseQuery("")).toThrow("Empty query");
 		});
 
 		test("unexpected token throws error", () => {
-			expect(() => parseQuery("age > 18 AND")).toThrow(ParseError);
+			expect(() => parseQuery("age > 18 AND")).toThrow(FiltronParseError);
 		});
 
 		test("unmatched parentheses throws error", () => {
-			expect(() => parseQuery("(age > 18")).toThrow(ParseError);
+			expect(() => parseQuery("(age > 18")).toThrow(FiltronParseError);
 			expect(() => parseQuery("(age > 18")).toThrow("Expected closing parenthesis");
 		});
 
 		test("empty array throws error", () => {
-			expect(() => parseQuery("status : []")).toThrow(ParseError);
+			expect(() => parseQuery("status : []")).toThrow(FiltronParseError);
 			expect(() => parseQuery("status : []")).toThrow("Array cannot be empty");
 		});
 
 		test("unclosed array throws error", () => {
-			expect(() => parseQuery('status : ["active"')).toThrow(ParseError);
+			expect(() => parseQuery('status : ["active"')).toThrow(FiltronParseError);
 		});
 
 		test("missing value in comparison throws error", () => {
-			expect(() => parseQuery("age >")).toThrow(ParseError);
+			expect(() => parseQuery("age >")).toThrow(FiltronParseError);
 		});
 
 		test("invalid token sequence throws error", () => {
-			expect(() => parseQuery("= =")).toThrow(ParseError);
+			expect(() => parseQuery("= =")).toThrow(FiltronParseError);
 		});
 
 		test("error includes position", () => {
 			try {
 				parseQuery("age > ");
 			} catch (error) {
-				expect(error).toBeInstanceOf(ParseError);
-				expect((error as ParseError).position).toBeGreaterThanOrEqual(0);
+				expect(error).toBeInstanceOf(FiltronParseError);
+				expect((error as FiltronParseError).position).toBeGreaterThanOrEqual(0);
 			}
 		});
 	});

--- a/packages/core/src/rd-parser.ts
+++ b/packages/core/src/rd-parser.ts
@@ -16,6 +16,7 @@
  *   RangeSuffix       = '..' NUMBER
  */
 
+import { FiltronParseError } from "./errors";
 import { Lexer, type Token, type TokenType, type StringToken, type NumberToken } from "./lexer";
 import type {
 	ASTNode,
@@ -28,19 +29,6 @@ import type {
 	BooleanFieldExpression,
 	RangeExpression,
 } from "./types";
-
-/**
- * Parser error with position information
- */
-export class ParseError extends Error {
-	constructor(
-		message: string,
-		public position: number,
-	) {
-		super(message);
-		this.name = "ParseError";
-	}
-}
 
 /**
  * Parser for Filtron queries
@@ -82,7 +70,7 @@ class Parser {
 	private expect(type: TokenType, message?: string): Token {
 		if (this.current.type !== type) {
 			const msg = message ?? `Expected ${type}, got ${this.current.type}`;
-			throw new ParseError(msg, this.current.start);
+			throw new FiltronParseError(msg, this.current.start);
 		}
 		return this.advance();
 	}
@@ -92,13 +80,13 @@ class Parser {
 	 */
 	parse(): ASTNode {
 		if (this.check("EOF")) {
-			throw new ParseError("Empty query", 0);
+			throw new FiltronParseError("Empty query", 0);
 		}
 
 		const result = this.parseOrExpression();
 
 		if (!this.check("EOF")) {
-			throw new ParseError(`Unexpected token: ${this.current.type}`, this.current.start);
+			throw new FiltronParseError(`Unexpected token: ${this.current.type}`, this.current.start);
 		}
 
 		return result;
@@ -273,7 +261,7 @@ class Parser {
 			case "COLON":
 				return ":";
 			default:
-				throw new ParseError(`Invalid operator: ${token.type}`, token.start);
+				throw new FiltronParseError(`Invalid operator: ${token.type}`, token.start);
 		}
 	}
 
@@ -319,7 +307,7 @@ class Parser {
 		this.expect("RBRACKET", "Expected ']' to close array");
 
 		if (values.length === 0) {
-			throw new ParseError("Array cannot be empty", this.current.start);
+			throw new FiltronParseError("Array cannot be empty", this.current.start);
 		}
 
 		return { type, field, values };
@@ -368,7 +356,7 @@ class Parser {
 			return { type: "identifier", value };
 		}
 
-		throw new ParseError(`Expected value, got ${t}`, this.current.start);
+		throw new FiltronParseError(`Expected value, got ${t}`, this.current.start);
 	}
 }
 
@@ -377,7 +365,7 @@ class Parser {
  *
  * @param input - The query string to parse
  * @returns The parsed AST
- * @throws ParseError if the query is invalid
+ * @throws FiltronParseError if the query is invalid
  */
 export function parseQuery(input: string): ASTNode {
 	const parser = new Parser(input);

--- a/website/lib/llms.ts
+++ b/website/lib/llms.ts
@@ -137,7 +137,7 @@ ${examplesSection}
 
 \`parse()\` returns a result object:
 - On success: \`{ success: true, ast: ASTNode }\`
-- On failure: \`{ success: false, error: string, position: number }\`
+- On failure: \`{ success: false, message: string, position?: number }\`
 
 \`parseOrThrow()\` throws \`FiltronParseError\` with \`message\` and \`position\` properties.
 

--- a/website/src/main.ts
+++ b/website/src/main.ts
@@ -163,7 +163,7 @@ function init(): void {
 		} else {
 			if (result.position !== undefined) {
 				filterHighlighted.innerHTML = toHtmlWithError(expression, result.position);
-				errorTooltip.textContent = result.error;
+				errorTooltip.textContent = result.message;
 				errorTooltip.hidden = false;
 			}
 			grid.applyFilter(null);


### PR DESCRIPTION
### Why

Three error classes (`LexerError`, `ParseError`, `FiltronParseError`) exposed overlapping surfaces, the `ParseResult` failure shape carried duplicate `error`/`message` fields, and `parseOrThrow` double-wrapped through `parse()`, losing the original stack.

### What

- One exported error type: `FiltronParseError` (`message`, `position?`) in a new `errors.ts`; lexer and parser throw it directly with identical messages and positions.
- `ParseResult` failure shape drops the duplicate `error` field (keeps `message` + `position?`); the failure interface is renamed `ParseError` → `ParseFailure` since the old name collided with the removed class.
- `parseOrThrow` calls the parser directly and rethrows the original error, preserving the stack and dropping the "Failed to parse Filtron query:" prefix; non-Filtron errors get wrapped.

Closes: #285