### PR TITLE
feat(core): export an AST walker

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -123,6 +123,23 @@ try {
 }
 ```
 
+### `walk(node: ASTNode, visitor: (node: ASTNode) => boolean | undefined): void`
+
+Walks an AST in pre-order depth-first order, calling the visitor on each node before its children. Return `false` from the visitor to skip a node's children.
+
+```typescript
+import { parseOrThrow, walk } from "@filtron/core";
+
+const ast = parseOrThrow('age > 18 AND status = "active"');
+const fields: string[] = [];
+walk(ast, (node) => {
+	if ("field" in node) {
+		fields.push(node.field);
+	}
+});
+// fields: ["age", "status"]
+```
+
 ## Types
 
 All AST types are exported for building custom consumers:

--- a/packages/core/examples/ast-inspection.ts
+++ b/packages/core/examples/ast-inspection.ts
@@ -1,26 +1,16 @@
 // Traversing the AST to extract all field names used in a query.
 // Run with: bun run examples/ast-inspection.ts
 
-import { parseOrThrow, type ASTNode } from "../src/index";
-
-function collectFields(node: ASTNode): string[] {
-	switch (node.type) {
-		case "or":
-		case "and":
-			return node.children.flatMap(collectFields);
-		case "not":
-			return collectFields(node.expression);
-		case "comparison":
-		case "oneOf":
-		case "exists":
-		case "booleanField":
-		case "range":
-			return [node.field];
-	}
-}
+import { parseOrThrow, walk } from "../src/index";
 
 const ast = parseOrThrow('(role = "admin" OR role = "user") AND verified AND age >= 21');
-const fields = [...new Set(collectFields(ast))];
 
-console.log("Fields:", fields);
+const fields = new Set<string>();
+walk(ast, (node) => {
+	if ("field" in node) {
+		fields.add(node.field);
+	}
+});
+
+console.log("Fields:", [...fields]);
 // Output: Fields: [ "role", "verified", "age" ]

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,9 @@
 export { parse, parseOrThrow, FiltronParseError } from "./parser";
 export type { ParseResult, ParseSuccess, ParseFailure } from "./parser";
 
+// AST walker
+export { walk } from "./walker";
+
 // Lexer for tokenization
 export { Lexer } from "./lexer";
 export type {

--- a/packages/core/src/walker.test.ts
+++ b/packages/core/src/walker.test.ts
@@ -1,0 +1,45 @@
+import { describe, test, expect } from "bun:test";
+import { parseOrThrow } from "./parser";
+import type { ASTNode } from "./types";
+import { walk } from "./walker";
+
+describe("walk()", () => {
+	test("visits every node type in pre-order with children in order", () => {
+		const ast = parseOrThrow(
+			'(a = 1 OR b : [1, 2]) AND NOT c !: ["x", "y"] AND d? AND e AND f = 1..5',
+		);
+		const visited: string[] = [];
+		walk(ast, (node) => {
+			visited.push("field" in node ? `${node.type}:${node.field}` : node.type);
+		});
+		expect(visited).toEqual([
+			"and",
+			"or",
+			"comparison:a",
+			"oneOf:b",
+			"not",
+			"oneOf:c",
+			"exists:d",
+			"booleanField:e",
+			"range:f",
+		]);
+	});
+
+	test("returning false skips a node's children but not its siblings", () => {
+		const ast = parseOrThrow("(a = 1 OR b = 2) AND NOT c AND d");
+		const visited: string[] = [];
+		walk(ast, (node) => {
+			visited.push("field" in node ? node.field : node.type);
+			if (node.type === "or" || node.type === "not") {
+				return false;
+			}
+			return true;
+		});
+		expect(visited).toEqual(["and", "or", "not", "d"]);
+	});
+
+	test("throws on unknown node type", () => {
+		const invalid = { type: "bogus" } as unknown as ASTNode;
+		expect(() => walk(invalid, () => undefined)).toThrow("Unknown node type: bogus");
+	});
+});

--- a/packages/core/src/walker.ts
+++ b/packages/core/src/walker.ts
@@ -1,0 +1,58 @@
+/**
+ * Pre-order depth-first traversal of a Filtron AST
+ */
+
+import type { ASTNode } from "./types";
+
+/**
+ * Walks an AST in pre-order depth-first order, calling the visitor on each node
+ *
+ * The visitor is called on a node before its children. Returning false from
+ * the visitor skips that node's children; any other return value (including
+ * undefined) descends. Children of "or" and "and" nodes are visited in order;
+ * "not" nodes descend through their expression. All other nodes are leaves.
+ *
+ * @param node - The AST node to walk
+ * @param visitor - Called once per visited node; return false to skip children
+ *
+ * @example
+ * ```typescript
+ * import { parseOrThrow, walk } from "@filtron/core";
+ *
+ * const ast = parseOrThrow('age > 18 AND status = "active"');
+ * const fields: string[] = [];
+ * walk(ast, (node) => {
+ *   if ("field" in node) {
+ *     fields.push(node.field);
+ *   }
+ * });
+ * // fields: ["age", "status"]
+ * ```
+ */
+export function walk(node: ASTNode, visitor: (node: ASTNode) => boolean | undefined): void {
+	if (visitor(node) === false) {
+		return;
+	}
+
+	switch (node.type) {
+		case "or":
+		case "and":
+			for (const child of node.children) {
+				walk(child, visitor);
+			}
+			return;
+		case "not":
+			walk(node.expression, visitor);
+			return;
+		case "comparison":
+		case "oneOf":
+		case "exists":
+		case "booleanField":
+		case "range":
+			return;
+		default:
+			// TypeScript exhaustiveness check
+			const _exhaustive: never = node;
+			throw new Error(`Unknown node type: ${(node as ASTNode).type}`);
+	}
+}

--- a/packages/core/src/walker.ts
+++ b/packages/core/src/walker.ts
@@ -50,9 +50,10 @@ export function walk(node: ASTNode, visitor: (node: ASTNode) => boolean | undefi
 		case "booleanField":
 		case "range":
 			return;
-		default:
+		default: {
 			// TypeScript exhaustiveness check
 			const _exhaustive: never = node;
 			throw new Error(`Unknown node type: ${(node as ASTNode).type}`);
+		}
 	}
 }


### PR DESCRIPTION
### Why

Adapters and downstream tooling each hand-roll AST traversal (the ast-inspection example did exactly that). With third-party adapters invited by the 3.0 API, recursion should come from the library.

### What

- `walk(node, visitor)` in @filtron/core: pre-order depth-first, visitor runs on a node before its descendants, returning `false` prunes that subtree. `or`/`and` recurse through `children` in order, `not` through `expression`; everything else is a leaf.
- The ast-inspection example now uses `walk()`; README documents the API.
- Tests cover every node type, traversal order, pruning, and the exhaustiveness guard; walker.ts at 100% coverage.


Closes: #267 
Closes: #289 