### PR TITLE
chore: bump node engine requirements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,13 +66,13 @@ jobs:
       matrix:
         include:
           - setup: node
-            version: "20"
-            test_cmd: node -e
-          - setup: node
             version: "22"
             test_cmd: node -e
           - setup: node
             version: "24"
+            test_cmd: node -e
+          - setup: node
+            version: "26"
             test_cmd: node -e
           - setup: bun
             version: "1.1"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 	},
 	"engines": {
 		"bun": ">=1.2.19",
-		"node": ">=20.0.0"
+		"node": ">=22.0.0"
 	},
 	"packageManager": "bun@1.3.14"
 }


### PR DESCRIPTION
**This is a breaking change**

### Why

Node 20.x is no longer supported upstream. Remove it.

### What

Bump lowest node to Node.js 22.x and add 26 while at it in CI.

Refs: https://github.com/jbergstroem/filtron/issues/293