### PR TITLE
feat(core): make ranges a value form instead of a node type

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,11 +84,11 @@ OrExpression    = AndExpression (OR AndExpression)*
 AndExpression   = NotExpression (AND NotExpression)*
 NotExpression   = NOT NotExpression | PrimaryExpression
 PrimaryExpression = '(' OrExpression ')' | '-' FieldName | FieldExpression
-FieldExpression = FieldName ('?' | EXISTS | ComparisonOp Value RangeSuffix? | OneOfOp '[' Values ']')?
-RangeSuffix     = '..' NUMBER
+FieldExpression = FieldName ('?' | EXISTS | ComparisonOp Value | OneOfOp '[' Values ']')?
 FieldName       = IDENT ('.' IDENT)*
 Values          = Value (',' Value)*
-Value           = STRING | NUMBER | BOOLEAN | DottedIdent
+Value           = STRING | NUMBER | BOOLEAN | DottedIdent | Range
+Range           = NUMBER '..' NUMBER
 ```
 
 ## Checklist: modifying parser

--- a/packages/conformance/src/index.ts
+++ b/packages/conformance/src/index.ts
@@ -206,6 +206,14 @@ export const cases: ConformanceCase[] = [
 		params: [18, 30],
 	},
 	{
+		name: "range-negated",
+		query: "age != 18..30",
+		matches: [2, 4, 6, 7, 8],
+		sql: "age NOT BETWEEN $1 AND $2",
+		params: [18, 30],
+		notes: "Ranges are values (#287); != means outside the interval and maps to NOT BETWEEN.",
+	},
+	{
 		name: "one-of-small",
 		query: 'status : ["active", "pending"]',
 		matches: [1, 2, 4, 8],

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -85,7 +85,7 @@ parse("user.profile.age >= 18");
 | `~`                  | Contains      | `name ~ "john"`       |
 | `?`, `EXISTS`        | Field exists  | `email?`              |
 | `-`                  | Field missing | `-email`              |
-| `..`                 | Range         | `age = 18..65`        |
+| `..`                 | Range value   | `age = 18..65`        |
 | `: [...]`            | One of        | `status : ["a", "b"]` |
 | `AND`, `OR`, `NOT`   | Boolean logic | `a AND (b OR c)`      |
 
@@ -184,7 +184,8 @@ import type { Token, TokenType, StringToken, NumberToken, BooleanToken } from "@
 | `exists`       | `field`, `negated`           | `email?`, `-email`    |
 | `booleanField` | `field`                      | `verified`            |
 | `oneOf`        | `field`, `values`, `negated` | `status : ["a", "b"]` |
-| `range`        | `field`, `min`, `max`        | `age = 18..65`        |
+
+Ranges are values, not nodes: `age = 18..65` produces a comparison whose value is `{ type: "range", min: 18, max: 65 }`. Ranges work with `=`, `:` and `!=` (outside the interval) and are rejected inside arrays.
 
 Chains of the same operator are flat: `a AND b AND c` produces a single `and` node with three children, never nested pairs.
 

--- a/packages/core/examples/query-syntax.ts
+++ b/packages/core/examples/query-syntax.ts
@@ -24,8 +24,9 @@ parseOrThrow('role : ["admin", "moderator", "user"]');
 // Not-one-of operator (!:)
 parseOrThrow('status !: ["deleted", "banned"]');
 
-// Range syntax for numeric ranges (inclusive)
+// Range values for numeric intervals (inclusive)
 parseOrThrow("age = 18..65");
+parseOrThrow("age != 18..65"); // outside the interval
 
 // Logical operators: AND, OR, NOT
 parseOrThrow('active AND role = "admin"');

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -42,7 +42,6 @@ export type {
 	OneOfExpression,
 	ExistsExpression,
 	BooleanFieldExpression,
-	RangeExpression,
 	StringValue,
 	NumberValue,
 	BooleanValue,

--- a/packages/core/src/rd-parser.test.ts
+++ b/packages/core/src/rd-parser.test.ts
@@ -232,6 +232,11 @@ describe("RD Parser", () => {
 			expect(() => parseQuery("age : [1, 18..65]")).toThrow(FiltronParseError);
 		});
 
+		test("inverted range is an error", () => {
+			expect(() => parseQuery("age = 65..18")).toThrow("Range min (65) must not exceed max (18)");
+			expect(() => parseQuery("age = 18..18")).not.toThrow();
+		});
+
 		test("incomplete range is an error", () => {
 			expect(() => parseQuery("age = 18..")).toThrow("Expected number after '..'");
 		});

--- a/packages/core/src/rd-parser.test.ts
+++ b/packages/core/src/rd-parser.test.ts
@@ -9,7 +9,6 @@ import type {
 	ExistsExpression,
 	BooleanFieldExpression,
 	OneOfExpression,
-	RangeExpression,
 } from "./types";
 
 describe("RD Parser", () => {
@@ -190,25 +189,51 @@ describe("RD Parser", () => {
 		});
 	});
 
-	describe("Range Expressions", () => {
+	describe("Range Values", () => {
 		test("basic integer range", () => {
-			const ast = parseQuery("age = 18..65") as RangeExpression;
-			expect(ast.type).toBe("range");
+			const ast = parseQuery("age = 18..65") as ComparisonExpression;
+			expect(ast.type).toBe("comparison");
 			expect(ast.field).toBe("age");
-			expect(ast.min).toBe(18);
-			expect(ast.max).toBe(65);
+			expect(ast.operator).toBe("=");
+			expect(ast.value).toEqual({ type: "range", min: 18, max: 65 });
 		});
 
 		test("float range", () => {
-			const ast = parseQuery("score = 0.0..100.0") as RangeExpression;
-			expect(ast.min).toBe(0.0);
-			expect(ast.max).toBe(100.0);
+			const ast = parseQuery("score = 0.0..100.0") as ComparisonExpression;
+			expect(ast.value).toEqual({ type: "range", min: 0, max: 100 });
 		});
 
 		test("negative number range", () => {
-			const ast = parseQuery("temperature = -10..30") as RangeExpression;
-			expect(ast.min).toBe(-10);
-			expect(ast.max).toBe(30);
+			const ast = parseQuery("temperature = -10..30") as ComparisonExpression;
+			expect(ast.value).toEqual({ type: "range", min: -10, max: 30 });
+		});
+
+		test("range with colon operator", () => {
+			const ast = parseQuery("age : 18..65") as ComparisonExpression;
+			expect(ast.operator).toBe(":");
+			expect(ast.value).toEqual({ type: "range", min: 18, max: 65 });
+		});
+
+		test("range with not-equals operator", () => {
+			const ast = parseQuery("age != 18..65") as ComparisonExpression;
+			expect(ast.operator).toBe("!=");
+			expect(ast.value).toEqual({ type: "range", min: 18, max: 65 });
+		});
+
+		test("range with an ordering operator is an error", () => {
+			expect(() => parseQuery("age > 18..65")).toThrow(
+				"Range values require the =, : or != operator",
+			);
+			expect(() => parseQuery("age <= 18..65")).toThrow(FiltronParseError);
+		});
+
+		test("range inside an array is an error", () => {
+			expect(() => parseQuery("age : [18..65]")).toThrow("Range values are not allowed in arrays");
+			expect(() => parseQuery("age : [1, 18..65]")).toThrow(FiltronParseError);
+		});
+
+		test("incomplete range is an error", () => {
+			expect(() => parseQuery("age = 18..")).toThrow("Expected number after '..'");
 		});
 	});
 

--- a/packages/core/src/rd-parser.ts
+++ b/packages/core/src/rd-parser.ts
@@ -362,6 +362,12 @@ class Parser {
 			if (this.check("DOTDOT")) {
 				this.advance();
 				const maxToken = this.expect("NUMBER", "Expected number after '..'") as NumberToken;
+				if (token.value > maxToken.value) {
+					throw new FiltronParseError(
+						`Range min (${token.value}) must not exceed max (${maxToken.value})`,
+						token.start,
+					);
+				}
 				return { type: "range", min: token.value, max: maxToken.value };
 			}
 			return { type: "number", value: token.value };

--- a/packages/core/src/rd-parser.ts
+++ b/packages/core/src/rd-parser.ts
@@ -9,11 +9,11 @@
  *   AndExpression     = NotExpression (AND NotExpression)*
  *   NotExpression     = NOT NotExpression | PrimaryExpression
  *   PrimaryExpression = '(' OrExpression ')' | '-' FieldName | FieldExpression
- *   FieldExpression   = FieldName ('?' | EXISTS | ComparisonOp Value RangeSuffix? | OneOfOp '[' Values ']')?
+ *   FieldExpression   = FieldName ('?' | EXISTS | ComparisonOp Value | OneOfOp '[' Values ']')?
  *   FieldName         = IDENT ('.' IDENT)*
- *   Value             = STRING | NUMBER | BOOLEAN | DottedIdent
- *   Values            = Value (',' Value)*
- *   RangeSuffix       = '..' NUMBER
+ *   Value             = STRING | NUMBER | BOOLEAN | DottedIdent | Range
+ *   Values            = Value (',' Value)*        (ranges are rejected)
+ *   Range             = NUMBER '..' NUMBER        (only with =, : or !=)
  */
 
 import { FiltronParseError } from "./errors";
@@ -26,7 +26,6 @@ import type {
 	OneOfExpression,
 	ExistsExpression,
 	BooleanFieldExpression,
-	RangeExpression,
 } from "./types";
 
 /**
@@ -192,7 +191,7 @@ class Parser {
 
 	/**
 	 * Parse field expression
-	 * FieldExpression = FieldName ('?' | EXISTS | ComparisonOp Value RangeSuffix? | OneOfOp '[' Values ']')?
+	 * FieldExpression = FieldName ('?' | EXISTS | ComparisonOp Value | OneOfOp '[' Values ']')?
 	 */
 	private parseFieldExpression(): ASTNode {
 		const field = this.parseFieldName();
@@ -230,28 +229,14 @@ class Parser {
 			const opToken = this.advance();
 			const operator = this.tokenToOperator(opToken);
 
-			// Check for range expression: field = min..max
-			if (operator === "=" && this.check("NUMBER")) {
-				const minToken = this.advance() as NumberToken;
-				const min = minToken.value;
-
-				if (this.check("DOTDOT")) {
-					this.advance();
-					const maxToken = this.expect("NUMBER", "Expected number after '..'") as NumberToken;
-					const max = maxToken.value;
-					return { type: "range", field, min, max } as RangeExpression;
-				}
-
-				// Not a range, just a regular comparison with a number
-				return {
-					type: "comparison",
-					field,
-					operator,
-					value: { type: "number", value: min },
-				} as ComparisonExpression;
+			const value = this.parseValue();
+			if (value.type === "range" && operator !== "=" && operator !== ":" && operator !== "!=") {
+				throw new FiltronParseError(
+					`Range values require the =, : or != operator, got ${operator}`,
+					opToken.start,
+				);
 			}
 
-			const value = this.parseValue();
 			return {
 				type: "comparison",
 				field,
@@ -329,11 +314,11 @@ class Parser {
 
 		// Handle non-empty array
 		if (!this.check("RBRACKET")) {
-			values.push(this.parseValue());
+			values.push(this.parseArrayValue());
 
 			while (this.check("COMMA")) {
 				this.advance(); // consume ,
-				values.push(this.parseValue());
+				values.push(this.parseArrayValue());
 			}
 		}
 
@@ -350,6 +335,18 @@ class Parser {
 	 * Parse a value
 	 * Value = STRING | NUMBER | BOOLEAN | DottedIdent
 	 */
+	/**
+	 * Parse a value inside a membership array, where ranges are not allowed
+	 */
+	private parseArrayValue(): Value {
+		const start = this.current.start;
+		const value = this.parseValue();
+		if (value.type === "range") {
+			throw new FiltronParseError("Range values are not allowed in arrays", start);
+		}
+		return value;
+	}
+
 	private parseValue(): Value {
 		const t = this.current.type;
 
@@ -359,9 +356,14 @@ class Parser {
 			return { type: "string", value: token.value };
 		}
 
-		// Number literal
+		// Number literal, or a range when followed by '..'
 		if (t === "NUMBER") {
 			const token = this.advance() as NumberToken;
+			if (this.check("DOTDOT")) {
+				this.advance();
+				const maxToken = this.expect("NUMBER", "Expected number after '..'") as NumberToken;
+				return { type: "range", min: token.value, max: maxToken.value };
+			}
 			return { type: "number", value: token.value };
 		}
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -12,13 +12,12 @@ export type ASTNode =
 	| ComparisonExpression
 	| OneOfExpression
 	| ExistsExpression
-	| BooleanFieldExpression
-	| RangeExpression;
+	| BooleanFieldExpression;
 
 /**
  * Value type - represents literal values in expressions
  */
-export type Value = StringValue | NumberValue | BooleanValue | IdentifierValue;
+export type Value = StringValue | NumberValue | BooleanValue | IdentifierValue | RangeValue;
 
 /**
  * Comparison operators supported
@@ -99,17 +98,6 @@ export interface BooleanFieldExpression {
 }
 
 /**
- * Range expression - checks if a field value is between two numbers (inclusive)
- * Example: age = 18..65, price = 0..100
- */
-export interface RangeExpression {
-	type: "range";
-	field: string;
-	min: number;
-	max: number;
-}
-
-/**
  * String value - a quoted string literal
  */
 export interface StringValue {
@@ -139,4 +127,15 @@ export interface BooleanValue {
 export interface IdentifierValue {
 	type: "identifier";
 	value: string;
+}
+
+/**
+ * Range value - an inclusive numeric interval
+ * Valid with the =, : and != operators only
+ * Example: age = 18..65, price != 0..100
+ */
+export interface RangeValue {
+	type: "range";
+	min: number;
+	max: number;
 }

--- a/packages/core/src/walker.test.ts
+++ b/packages/core/src/walker.test.ts
@@ -21,7 +21,7 @@ describe("walk()", () => {
 			"oneOf:c",
 			"exists:d",
 			"booleanField:e",
-			"range:f",
+			"comparison:f",
 		]);
 	});
 

--- a/packages/core/src/walker.ts
+++ b/packages/core/src/walker.ts
@@ -48,7 +48,6 @@ export function walk(node: ASTNode, visitor: (node: ASTNode) => boolean | undefi
 		case "oneOf":
 		case "exists":
 		case "booleanField":
-		case "range":
 			return;
 		default: {
 			// TypeScript exhaustiveness check

--- a/packages/js/src/filter.test.ts
+++ b/packages/js/src/filter.test.ts
@@ -7,7 +7,6 @@ import type {
 	OneOfExpression,
 	ExistsExpression,
 	BooleanFieldExpression,
-	RangeExpression,
 } from "@filtron/core";
 import { toFilter, nestedAccessor } from "./filter.js";
 
@@ -191,11 +190,11 @@ describe("toFilter", () => {
 
 	describe("Range Expression", () => {
 		test("basic range", () => {
-			const ast: RangeExpression = {
-				type: "range",
+			const ast: ComparisonExpression = {
+				type: "comparison",
 				field: "age",
-				min: 18,
-				max: 65,
+				operator: "=",
+				value: { type: "range", min: 18, max: 65 },
 			};
 			const filter = toFilter(ast);
 			expect(filter({ age: 18 })).toBe(true);
@@ -203,6 +202,67 @@ describe("toFilter", () => {
 			expect(filter({ age: 30 })).toBe(true);
 			expect(filter({ age: 17 })).toBe(false);
 			expect(filter({ age: "30" })).toBe(false); // non-number returns false
+		});
+	});
+
+	describe("Range Values", () => {
+		test("negated range matches outside the interval", () => {
+			const ast: ComparisonExpression = {
+				type: "comparison",
+				field: "age",
+				operator: "!=",
+				value: { type: "range", min: 18, max: 65 },
+			};
+			const filter = toFilter(ast);
+			expect(filter({ age: 17 })).toBe(true);
+			expect(filter({ age: 66 })).toBe(true);
+			expect(filter({ age: 18 })).toBe(false);
+			expect(filter({ age: 65 })).toBe(false);
+			expect(filter({ age: "30" })).toBe(true); // non-numbers are outside any range
+		});
+
+		test("negated range with custom accessor", () => {
+			const ast: ComparisonExpression = {
+				type: "comparison",
+				field: "age",
+				operator: "!=",
+				value: { type: "range", min: 18, max: 65 },
+			};
+			const filter = toFilter(ast, { fieldAccessor: (obj, field) => obj[field] });
+			expect(filter({ age: 17 })).toBe(true);
+			expect(filter({ age: 30 })).toBe(false);
+		});
+
+		test("range with colon operator matches the interval", () => {
+			const ast: ComparisonExpression = {
+				type: "comparison",
+				field: "age",
+				operator: ":",
+				value: { type: "range", min: 18, max: 65 },
+			};
+			const filter = toFilter(ast);
+			expect(filter({ age: 30 })).toBe(true);
+			expect(filter({ age: 17 })).toBe(false);
+		});
+
+		test("range with an ordering operator throws", () => {
+			const ast: ComparisonExpression = {
+				type: "comparison",
+				field: "age",
+				operator: ">",
+				value: { type: "range", min: 18, max: 65 },
+			};
+			expect(() => toFilter(ast)).toThrow("Range values require the =, : or != operator");
+		});
+
+		test("range value outside a comparison throws", () => {
+			const ast: OneOfExpression = {
+				type: "oneOf",
+				field: "age",
+				negated: false,
+				values: [{ type: "range", min: 1, max: 2 }],
+			};
+			expect(() => toFilter(ast)).toThrow("Range values cannot be used here");
 		});
 	});
 
@@ -389,7 +449,15 @@ describe("toFilter", () => {
 			).toThrow('Field "x" is not allowed');
 
 			expect(() =>
-				toFilter({ type: "range", field: "x", min: 0, max: 1 }, { allowedFields: [] }),
+				toFilter(
+					{
+						type: "comparison",
+						field: "x",
+						operator: "=",
+						value: { type: "range", min: 0, max: 1 },
+					},
+					{ allowedFields: [] },
+				),
 			).toThrow('Field "x" is not allowed');
 		});
 	});
@@ -565,12 +633,12 @@ describe("toFilter", () => {
 			expect(filter({ email: null })).toBe(false);
 		});
 
-		test("works with range expression", () => {
-			const ast: RangeExpression = {
-				type: "range",
+		test("works with range values", () => {
+			const ast: ComparisonExpression = {
+				type: "comparison",
 				field: "user_age",
-				min: 18,
-				max: 65,
+				operator: "=",
+				value: { type: "range", min: 18, max: 65 },
 			};
 			const filter = toFilter(ast, {
 				fieldMapping: {
@@ -706,7 +774,12 @@ describe("toFilter", () => {
 		test("exists, booleanField and range with custom accessor", () => {
 			const exists: ExistsExpression = { type: "exists", negated: false, field: "email" };
 			const boolField: BooleanFieldExpression = { type: "booleanField", field: "verified" };
-			const range: RangeExpression = { type: "range", field: "age", min: 18, max: 65 };
+			const range: ComparisonExpression = {
+				type: "comparison",
+				field: "age",
+				operator: "=",
+				value: { type: "range", min: 18, max: 65 },
+			};
 			const opts = { fieldAccessor: accessor };
 			expect(toFilter(exists, opts)({ email: "a@b.c" })).toBe(true);
 			expect(toFilter(exists, opts)({ email: null })).toBe(false);

--- a/packages/js/src/filter.ts
+++ b/packages/js/src/filter.ts
@@ -13,7 +13,6 @@ import type {
 	OneOfExpression,
 	ExistsExpression,
 	BooleanFieldExpression,
-	RangeExpression,
 } from "@filtron/core";
 
 /**
@@ -164,8 +163,6 @@ function generateFilter(
 			return generateExists(node, state);
 		case "booleanField":
 			return generateBooleanField(node, state);
-		case "range":
-			return generateRange(node, state);
 		default:
 			// TypeScript exhaustiveness check
 			const _exhaustive: never = node;
@@ -274,6 +271,18 @@ function generateComparison(
 	state: GeneratorState,
 ): FilterPredicate<Record<string, unknown>> {
 	const field = resolveField(node.field, state);
+
+	if (node.value.type === "range") {
+		const { min, max } = node.value;
+		if (node.operator === "=" || node.operator === ":") {
+			return generateRangeComparison(field, "=", min, max, state);
+		}
+		if (node.operator === "!=") {
+			return generateRangeComparison(field, "!=", min, max, state);
+		}
+		throw new Error(`Range values require the =, : or != operator, got ${node.operator}`);
+	}
+
 	const targetValue = extractValue(node.value);
 	const accessor = state.fieldAccessor;
 
@@ -589,15 +598,30 @@ function generateBooleanField(
 }
 
 /**
- * Generates predicate for range expression (BETWEEN)
+ * Generates predicate for a comparison against a range value
+ * = and : match numbers inside the inclusive interval; != matches
+ * everything else, including non-numbers
  */
-function generateRange(
-	node: RangeExpression,
+function generateRangeComparison(
+	field: string,
+	operator: "=" | ":" | "!=",
+	min: number,
+	max: number,
 	state: GeneratorState,
 ): FilterPredicate<Record<string, unknown>> {
-	const field = resolveField(node.field, state);
 	const accessor = state.fieldAccessor;
-	const { min, max } = node;
+	if (operator === "!=") {
+		if (accessor) {
+			return (item) => {
+				const fieldValue = accessor(item, field);
+				return typeof fieldValue !== "number" || fieldValue < min || fieldValue > max;
+			};
+		}
+		return (item) => {
+			const fieldValue = item[field];
+			return typeof fieldValue !== "number" || fieldValue < min || fieldValue > max;
+		};
+	}
 	if (accessor) {
 		return (item) => {
 			const fieldValue = accessor(item, field);
@@ -615,6 +639,9 @@ function generateRange(
  */
 function extractValue(value: Value): string | number | boolean {
 	switch (value.type) {
+		case "range":
+			// The parser only produces ranges where callers handle them first
+			throw new Error("Range values cannot be used here");
 		case "string":
 			return value.value;
 		case "number":

--- a/packages/sql/src/converter.test.ts
+++ b/packages/sql/src/converter.test.ts
@@ -259,10 +259,10 @@ describe("SQL", () => {
 	describe("Range Expressions", () => {
 		test("basic integer range", () => {
 			const ast: ASTNode = {
-				type: "range",
+				type: "comparison",
 				field: "age",
-				min: 18,
-				max: 65,
+				operator: "=",
+				value: { type: "range", min: 18, max: 65 },
 			};
 
 			const result = toSQL(ast);
@@ -272,10 +272,10 @@ describe("SQL", () => {
 
 		test("float range", () => {
 			const ast: ASTNode = {
-				type: "range",
+				type: "comparison",
 				field: "price",
-				min: 9.99,
-				max: 99.99,
+				operator: "=",
+				value: { type: "range", min: 9.99, max: 99.99 },
 			};
 
 			const result = toSQL(ast);
@@ -285,10 +285,10 @@ describe("SQL", () => {
 
 		test("negative number range", () => {
 			const ast: ASTNode = {
-				type: "range",
+				type: "comparison",
 				field: "temperature",
-				min: -20,
-				max: 40,
+				operator: "=",
+				value: { type: "range", min: -20, max: 40 },
 			};
 
 			const result = toSQL(ast);
@@ -296,12 +296,59 @@ describe("SQL", () => {
 			expect(result.params).toEqual([-20, 40]);
 		});
 
+		test("negated range uses NOT BETWEEN", () => {
+			const ast: ASTNode = {
+				type: "comparison",
+				field: "age",
+				operator: "!=",
+				value: { type: "range", min: 18, max: 65 },
+			};
+
+			const result = toSQL(ast);
+			expect(result.sql).toBe("age NOT BETWEEN $1 AND $2");
+			expect(result.params).toEqual([18, 65]);
+		});
+
+		test("range with colon operator uses BETWEEN", () => {
+			const ast: ASTNode = {
+				type: "comparison",
+				field: "age",
+				operator: ":",
+				value: { type: "range", min: 18, max: 65 },
+			};
+
+			const result = toSQL(ast);
+			expect(result.sql).toBe("age BETWEEN $1 AND $2");
+		});
+
+		test("range with an ordering operator throws", () => {
+			const ast: ASTNode = {
+				type: "comparison",
+				field: "age",
+				operator: ">",
+				value: { type: "range", min: 18, max: 65 },
+			};
+
+			expect(() => toSQL(ast)).toThrow("Range values require the =, : or != operator");
+		});
+
+		test("range value outside a comparison throws", () => {
+			const ast: ASTNode = {
+				type: "oneOf",
+				field: "age",
+				negated: false,
+				values: [{ type: "range", min: 1, max: 2 }],
+			};
+
+			expect(() => toSQL(ast)).toThrow("Range values cannot be used here");
+		});
+
 		test("range with field mapper", () => {
 			const ast: ASTNode = {
-				type: "range",
+				type: "comparison",
 				field: "user.age",
-				min: 18,
-				max: 65,
+				operator: "=",
+				value: { type: "range", min: 18, max: 65 },
 			};
 
 			const result = toSQL(ast, {

--- a/packages/sql/src/converter.ts
+++ b/packages/sql/src/converter.ts
@@ -13,7 +13,6 @@ import type {
 	ComparisonExpression,
 	ExistsExpression,
 	BooleanFieldExpression,
-	RangeExpression,
 } from "@filtron/core";
 
 /**
@@ -159,8 +158,6 @@ function generateSQL(node: ASTNode, state: GeneratorState): string {
 			return generateExists(node, state);
 		case "booleanField":
 			return generateBooleanField(node, state);
-		case "range":
-			return generateRange(node, state);
 		default:
 			// TypeScript exhaustiveness check
 			const _exhaustive: never = node;
@@ -205,6 +202,19 @@ function generateNot(node: NotExpression, state: GeneratorState): string {
  */
 function generateComparison(node: ComparisonExpression, state: GeneratorState): string {
 	const field = state.fieldMapper(node.field);
+
+	if (node.value.type === "range") {
+		const minParam = addParameter(node.value.min, state);
+		const maxParam = addParameter(node.value.max, state);
+		if (node.operator === "=" || node.operator === ":") {
+			return `${field} BETWEEN ${minParam} AND ${maxParam}`;
+		}
+		if (node.operator === "!=") {
+			return `${field} NOT BETWEEN ${minParam} AND ${maxParam}`;
+		}
+		throw new Error(`Range values require the =, : or != operator, got ${node.operator}`);
+	}
+
 	const operator = mapComparisonOperator(node.operator);
 
 	// Apply the resolved LIKE value transform for the ~ operator
@@ -261,16 +271,6 @@ function generateBooleanField(node: BooleanFieldExpression, state: GeneratorStat
 }
 
 /**
- * Generates SQL for range expression (BETWEEN)
- */
-function generateRange(node: RangeExpression, state: GeneratorState): string {
-	const field = state.fieldMapper(node.field);
-	const minParam = addParameter(node.min, state);
-	const maxParam = addParameter(node.max, state);
-	return `${field} BETWEEN ${minParam} AND ${maxParam}`;
-}
-
-/**
  * Maps Filtron comparison operators to SQL operators
  */
 function mapComparisonOperator(operator: ComparisonOperator): string {
@@ -301,6 +301,9 @@ function mapComparisonOperator(operator: ComparisonOperator): string {
  */
 function extractValue(value: Value): string | number | boolean {
 	switch (value.type) {
+		case "range":
+			// The parser only produces ranges where callers handle them first
+			throw new Error("Range values cannot be used here");
 		case "string":
 			return value.value;
 		case "number":


### PR DESCRIPTION
### Why

**This is a breaking change**

`age = 18..65` overloaded `=` through a parser special case and a dedicated node type. As a value form, ranges compose with future value kinds — dates (#265) get `created: 2024-01-01..2024-06-30` for free — and the special case disappears.

### What

- `RangeValue { type: "range", min, max }` joins the Value union; `RangeExpression` is deleted. `age = 18..65` parses as a plain comparison with a range value.
- New capability: `age != 18..65` means outside the interval (`NOT BETWEEN` in sql; js treats non-numbers as outside, mirroring the existing type guard). `:` works like `=`.
- Ordering operators (`>`, `>=`, `<`, `<=`, `~`) reject range values at parse time; ranges inside `[...]` arrays are a parse error. Both keep adapter membership/comparison code simple; lifting the array restriction later is additive.
- Adapters branch on the value kind in `generateComparison`; range node cases and generators removed from js, sql, and the walker. `extractValue` throws on ranges as a hand-built-AST guard.

Closes #287