### PR TITLE
feat(core): add parse limits for query length and nesting depth

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -114,11 +114,19 @@ bound how large a query can be:
 | `maxLength` | 10000   | Maximum query length in characters                       |
 | `maxDepth`  | 64      | Maximum combined nesting of parenthesized groups and NOT |
 
-Queries exceeding a limit fail with a `FiltronParseError`. Pass larger numbers
-to raise the limits:
+Queries exceeding a limit fail with a `FiltronParseError`:
 
 ```typescript
-const result = parse(userInput, { maxLength: 500, maxDepth: 8 });
+const userInput = '(role = "admin" OR role = "moderator") AND verified';
+
+// Safe: tighten the limits for untrusted input
+const safeResult = parse(userInput, { maxLength: 500, maxDepth: 8 });
+
+// Unsafe: raising the limits removes the guard against pathological queries
+const unsafeResult = parse(userInput, {
+	maxLength: Number.MAX_SAFE_INTEGER,
+	maxDepth: Number.MAX_SAFE_INTEGER,
+});
 ```
 
 ### `parseOrThrow(input: string, options?: ParseOptions): ASTNode`

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -91,7 +91,7 @@ parse("user.profile.age >= 18");
 
 ## API
 
-### `parse(input: string): ParseResult`
+### `parse(input: string, options?: ParseOptions): ParseResult`
 
 Parses a filter expression and returns a result object.
 
@@ -106,7 +106,22 @@ if (result.success) {
 }
 ```
 
-### `parseOrThrow(input: string): ASTNode`
+Both `parse` and `parseOrThrow` accept an optional `ParseOptions` object to
+bound how large a query can be:
+
+| Option      | Default | Meaning                                                  |
+| ----------- | ------- | -------------------------------------------------------- |
+| `maxLength` | 10000   | Maximum query length in characters                       |
+| `maxDepth`  | 64      | Maximum combined nesting of parenthesized groups and NOT |
+
+Queries exceeding a limit fail with a `FiltronParseError`. Pass larger numbers
+to raise the limits:
+
+```typescript
+const result = parse(userInput, { maxLength: 500, maxDepth: 8 });
+```
+
+### `parseOrThrow(input: string, options?: ParseOptions): ASTNode`
 
 Parses a filter expression, throwing `FiltronParseError` on invalid input. The same error class is used for all parse failures, whether they originate in the lexer or the parser.
 
@@ -147,6 +162,7 @@ All AST types are exported for building custom consumers:
 ```typescript
 import {
 	FiltronParseError, // Error class for all parse failures
+	type ParseOptions,
 	type ParseResult,
 	type ASTNode,
 	type AndExpression,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,7 +14,7 @@
 
 // Parser functions
 export { parse, parseOrThrow, FiltronParseError } from "./parser";
-export type { ParseResult, ParseSuccess, ParseFailure } from "./parser";
+export type { ParseOptions, ParseResult, ParseSuccess, ParseFailure } from "./parser";
 
 // AST walker
 export { walk } from "./walker";

--- a/packages/core/src/parser.test.ts
+++ b/packages/core/src/parser.test.ts
@@ -168,6 +168,43 @@ describe("Parser API", () => {
 		});
 	});
 
+	describe("ParseOptions", () => {
+		test("parse() accepts limits and returns failure with position", () => {
+			const result = parse("age > 18", { maxLength: 5 });
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.message).toBe("Query exceeds maximum length of 5 characters");
+				expect(result.position).toBe(0);
+			}
+		});
+
+		test("parse() returns failure when nesting exceeds maxDepth", () => {
+			const result = parse("((a))", { maxDepth: 1 });
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.message).toBe("Query exceeds maximum nesting depth of 1");
+				expect(result.position).toBe(1);
+			}
+		});
+
+		test("parse() succeeds with raised limits", () => {
+			const result = parse("(".repeat(70) + "a" + ")".repeat(70), { maxDepth: 70 });
+			expect(result.success).toBe(true);
+		});
+
+		test("parseOrThrow() accepts limits and throws FiltronParseError", () => {
+			expect(() => parseOrThrow("NOT NOT a", { maxDepth: 1 })).toThrow(FiltronParseError);
+			expect(() => parseOrThrow("NOT NOT a", { maxDepth: 1 })).toThrow(
+				"Query exceeds maximum nesting depth of 1",
+			);
+		});
+
+		test("parseOrThrow() succeeds within custom limits", () => {
+			const ast = parseOrThrow("NOT NOT a", { maxDepth: 2, maxLength: 9 });
+			expect(ast.type).toBe("not");
+		});
+	});
+
 	describe("Integration Tests", () => {
 		test("parse and parseOrThrow produce same AST for valid input", () => {
 			const query = "age > 18 AND verified = true";

--- a/packages/core/src/parser.test.ts
+++ b/packages/core/src/parser.test.ts
@@ -169,7 +169,7 @@ describe("Parser API", () => {
 	});
 
 	describe("ParseOptions", () => {
-		test("parse() accepts limits and returns failure with position", () => {
+		test("parse() forwards options and maps the failure", () => {
 			const result = parse("age > 18", { maxLength: 5 });
 			expect(result.success).toBe(false);
 			if (!result.success) {
@@ -178,30 +178,15 @@ describe("Parser API", () => {
 			}
 		});
 
-		test("parse() returns failure when nesting exceeds maxDepth", () => {
-			const result = parse("((a))", { maxDepth: 1 });
-			expect(result.success).toBe(false);
-			if (!result.success) {
-				expect(result.message).toBe("Query exceeds maximum nesting depth of 1");
-				expect(result.position).toBe(1);
+		test("parseOrThrow() forwards options and rethrows", () => {
+			let error: unknown;
+			try {
+				parseOrThrow("NOT NOT a", { maxDepth: 1 });
+			} catch (caught) {
+				error = caught;
 			}
-		});
-
-		test("parse() succeeds with raised limits", () => {
-			const result = parse("(".repeat(70) + "a" + ")".repeat(70), { maxDepth: 70 });
-			expect(result.success).toBe(true);
-		});
-
-		test("parseOrThrow() accepts limits and throws FiltronParseError", () => {
-			expect(() => parseOrThrow("NOT NOT a", { maxDepth: 1 })).toThrow(FiltronParseError);
-			expect(() => parseOrThrow("NOT NOT a", { maxDepth: 1 })).toThrow(
-				"Query exceeds maximum nesting depth of 1",
-			);
-		});
-
-		test("parseOrThrow() succeeds within custom limits", () => {
-			const ast = parseOrThrow("NOT NOT a", { maxDepth: 2, maxLength: 9 });
-			expect(ast.type).toBe("not");
+			expect(error).toBeInstanceOf(FiltronParseError);
+			expect((error as FiltronParseError).message).toBe("Query exceeds maximum nesting depth of 1");
 		});
 	});
 

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -9,6 +9,22 @@ import type { ASTNode } from "./types";
 export { FiltronParseError } from "./errors";
 
 /**
+ * Limits applied while parsing a query. Both values are upper bounds;
+ * pass larger numbers to raise them.
+ */
+export interface ParseOptions {
+	/**
+	 * Maximum query length in characters. Defaults to 10000.
+	 */
+	maxLength?: number;
+	/**
+	 * Maximum combined nesting depth of parenthesized groups and NOT
+	 * expressions. Defaults to 64.
+	 */
+	maxDepth?: number;
+}
+
+/**
  * Result of a successful parse operation
  */
 export interface ParseSuccess {
@@ -34,6 +50,7 @@ export type ParseResult = ParseSuccess | ParseFailure;
  * Parses a Filtron query string into an Abstract Syntax Tree (AST).
  *
  * @param query - The Filtron query string to parse
+ * @param options - Optional parse limits, see {@link ParseOptions}
  * @returns A ParseResult containing either the AST or an error
  *
  * @example
@@ -46,9 +63,9 @@ export type ParseResult = ParseSuccess | ParseFailure;
  * }
  * ```
  */
-export const parse = (query: string): ParseResult => {
+export const parse = (query: string, options?: ParseOptions): ParseResult => {
 	try {
-		const ast = parseQuery(query);
+		const ast = parseQuery(query, options);
 		return {
 			success: true,
 			ast,
@@ -74,6 +91,7 @@ export const parse = (query: string): ParseResult => {
  * Use this when you want to handle errors with try/catch instead of checking the result.
  *
  * @param query - The Filtron query string to parse
+ * @param options - Optional parse limits, see {@link ParseOptions}
  * @returns The parsed AST
  * @throws FiltronParseError if parsing fails, with position information
  *
@@ -89,9 +107,9 @@ export const parse = (query: string): ParseResult => {
  * }
  * ```
  */
-export const parseOrThrow = (query: string): ASTNode => {
+export const parseOrThrow = (query: string, options?: ParseOptions): ASTNode => {
 	try {
-		return parseQuery(query);
+		return parseQuery(query, options);
 	} catch (error) {
 		if (error instanceof FiltronParseError) {
 			throw error;

--- a/packages/core/src/rd-parser.test.ts
+++ b/packages/core/src/rd-parser.test.ts
@@ -386,74 +386,61 @@ describe("RD Parser", () => {
 	});
 
 	describe("Parse Limits", () => {
-		test("query at default maximum length passes", () => {
-			const ast = parseQuery("a".repeat(10000));
-			expect(ast.type).toBe("booleanField");
-		});
+		test("default maximum length is a boundary", () => {
+			expect(parseQuery("a".repeat(10000)).type).toBe("booleanField");
 
-		test("query over default maximum length throws", () => {
+			let error: unknown;
 			try {
 				parseQuery("a".repeat(10001));
-				expect(true).toBe(false); // Should not reach here
-			} catch (error) {
-				expect(error).toBeInstanceOf(FiltronParseError);
-				expect((error as FiltronParseError).message).toBe(
-					"Query exceeds maximum length of 10000 characters",
-				);
-				expect((error as FiltronParseError).position).toBe(0);
+			} catch (caught) {
+				error = caught;
 			}
+			expect(error).toBeInstanceOf(FiltronParseError);
+			expect((error as FiltronParseError).message).toBe(
+				"Query exceeds maximum length of 10000 characters",
+			);
+			expect((error as FiltronParseError).position).toBe(0);
 		});
 
-		test("custom maxLength lowers the limit", () => {
+		test("default maximum parenthesis depth is a boundary", () => {
+			expect(parseQuery("(".repeat(64) + "a" + ")".repeat(64)).type).toBe("booleanField");
+
+			let error: unknown;
+			try {
+				parseQuery("(".repeat(65) + "a" + ")".repeat(65));
+			} catch (caught) {
+				error = caught;
+			}
+			expect(error).toBeInstanceOf(FiltronParseError);
+			expect((error as FiltronParseError).message).toBe(
+				"Query exceeds maximum nesting depth of 64",
+			);
+			expect((error as FiltronParseError).position).toBe(64);
+		});
+
+		test("NOT chains count toward the depth limit", () => {
+			expect(parseQuery("NOT ".repeat(64) + "a").type).toBe("not");
+
+			let error: unknown;
+			try {
+				parseQuery("NOT ".repeat(65) + "a");
+			} catch (caught) {
+				error = caught;
+			}
+			expect(error).toBeInstanceOf(FiltronParseError);
+			expect((error as FiltronParseError).position).toBe(256);
+		});
+
+		test("custom limits lower and raise the defaults", () => {
 			expect(() => parseQuery("age > 18", { maxLength: 5 })).toThrow(
 				"Query exceeds maximum length of 5 characters",
 			);
-		});
-
-		test("query at custom maxLength passes", () => {
-			const ast = parseQuery("a = 1", { maxLength: 5 });
-			expect(ast.type).toBe("comparison");
-		});
-
-		test("custom maxLength raises the limit", () => {
-			const ast = parseQuery(`name = "${"a".repeat(15000)}"`, { maxLength: 20000 });
-			expect(ast.type).toBe("comparison");
-		});
-
-		test("parentheses at default maximum depth pass", () => {
-			const ast = parseQuery("(".repeat(64) + "a" + ")".repeat(64));
-			expect(ast.type).toBe("booleanField");
-		});
-
-		test("parentheses over default maximum depth throw", () => {
-			try {
-				parseQuery("(".repeat(65) + "a" + ")".repeat(65));
-				expect(true).toBe(false); // Should not reach here
-			} catch (error) {
-				expect(error).toBeInstanceOf(FiltronParseError);
-				expect((error as FiltronParseError).message).toBe(
-					"Query exceeds maximum nesting depth of 64",
-				);
-				expect((error as FiltronParseError).position).toBe(64);
-			}
-		});
-
-		test("NOT chain at default maximum depth passes", () => {
-			const ast = parseQuery("NOT ".repeat(64) + "a");
-			expect(ast.type).toBe("not");
-		});
-
-		test("NOT chain over default maximum depth throws", () => {
-			try {
-				parseQuery("NOT ".repeat(65) + "a");
-				expect(true).toBe(false); // Should not reach here
-			} catch (error) {
-				expect(error).toBeInstanceOf(FiltronParseError);
-				expect((error as FiltronParseError).message).toBe(
-					"Query exceeds maximum nesting depth of 64",
-				);
-				expect((error as FiltronParseError).position).toBe(256);
-			}
+			expect(parseQuery(`name = "${"a".repeat(15000)}"`, { maxLength: 20000 }).type).toBe(
+				"comparison",
+			);
+			expect(parseQuery("(".repeat(100) + "a" + ")".repeat(100), { maxDepth: 128 }).type).toBe(
+				"booleanField",
+			);
 		});
 
 		test("NOT and parentheses share the depth counter", () => {
@@ -461,11 +448,6 @@ describe("RD Parser", () => {
 			expect(() => parseQuery("NOT (a)", { maxDepth: 1 })).toThrow(
 				"Query exceeds maximum nesting depth of 1",
 			);
-		});
-
-		test("custom maxDepth raises the limit", () => {
-			const ast = parseQuery("(".repeat(100) + "a" + ")".repeat(100), { maxDepth: 128 });
-			expect(ast.type).toBe("booleanField");
 		});
 
 		test("depth counter resets between sibling groups", () => {

--- a/packages/core/src/rd-parser.test.ts
+++ b/packages/core/src/rd-parser.test.ts
@@ -384,4 +384,93 @@ describe("RD Parser", () => {
 			expect(ast.type).toBe("and");
 		});
 	});
+
+	describe("Parse Limits", () => {
+		test("query at default maximum length passes", () => {
+			const ast = parseQuery("a".repeat(10000));
+			expect(ast.type).toBe("booleanField");
+		});
+
+		test("query over default maximum length throws", () => {
+			try {
+				parseQuery("a".repeat(10001));
+				expect(true).toBe(false); // Should not reach here
+			} catch (error) {
+				expect(error).toBeInstanceOf(FiltronParseError);
+				expect((error as FiltronParseError).message).toBe(
+					"Query exceeds maximum length of 10000 characters",
+				);
+				expect((error as FiltronParseError).position).toBe(0);
+			}
+		});
+
+		test("custom maxLength lowers the limit", () => {
+			expect(() => parseQuery("age > 18", { maxLength: 5 })).toThrow(
+				"Query exceeds maximum length of 5 characters",
+			);
+		});
+
+		test("query at custom maxLength passes", () => {
+			const ast = parseQuery("a = 1", { maxLength: 5 });
+			expect(ast.type).toBe("comparison");
+		});
+
+		test("custom maxLength raises the limit", () => {
+			const ast = parseQuery(`name = "${"a".repeat(15000)}"`, { maxLength: 20000 });
+			expect(ast.type).toBe("comparison");
+		});
+
+		test("parentheses at default maximum depth pass", () => {
+			const ast = parseQuery("(".repeat(64) + "a" + ")".repeat(64));
+			expect(ast.type).toBe("booleanField");
+		});
+
+		test("parentheses over default maximum depth throw", () => {
+			try {
+				parseQuery("(".repeat(65) + "a" + ")".repeat(65));
+				expect(true).toBe(false); // Should not reach here
+			} catch (error) {
+				expect(error).toBeInstanceOf(FiltronParseError);
+				expect((error as FiltronParseError).message).toBe(
+					"Query exceeds maximum nesting depth of 64",
+				);
+				expect((error as FiltronParseError).position).toBe(64);
+			}
+		});
+
+		test("NOT chain at default maximum depth passes", () => {
+			const ast = parseQuery("NOT ".repeat(64) + "a");
+			expect(ast.type).toBe("not");
+		});
+
+		test("NOT chain over default maximum depth throws", () => {
+			try {
+				parseQuery("NOT ".repeat(65) + "a");
+				expect(true).toBe(false); // Should not reach here
+			} catch (error) {
+				expect(error).toBeInstanceOf(FiltronParseError);
+				expect((error as FiltronParseError).message).toBe(
+					"Query exceeds maximum nesting depth of 64",
+				);
+				expect((error as FiltronParseError).position).toBe(256);
+			}
+		});
+
+		test("NOT and parentheses share the depth counter", () => {
+			expect(parseQuery("NOT (a)", { maxDepth: 2 }).type).toBe("not");
+			expect(() => parseQuery("NOT (a)", { maxDepth: 1 })).toThrow(
+				"Query exceeds maximum nesting depth of 1",
+			);
+		});
+
+		test("custom maxDepth raises the limit", () => {
+			const ast = parseQuery("(".repeat(100) + "a" + ")".repeat(100), { maxDepth: 128 });
+			expect(ast.type).toBe("booleanField");
+		});
+
+		test("depth counter resets between sibling groups", () => {
+			const ast = parseQuery("NOT a AND (b) AND (c OR (d))", { maxDepth: 2 });
+			expect(ast.type).toBe("and");
+		});
+	});
 });

--- a/packages/core/src/rd-parser.ts
+++ b/packages/core/src/rd-parser.ts
@@ -18,6 +18,7 @@
 
 import { FiltronParseError } from "./errors";
 import { Lexer, type Token, type TokenType, type StringToken, type NumberToken } from "./lexer";
+import type { ParseOptions } from "./parser";
 import type {
 	ASTNode,
 	Value,
@@ -30,14 +31,30 @@ import type {
 } from "./types";
 
 /**
+ * Default maximum query length in characters
+ */
+const DEFAULT_MAX_LENGTH = 10000;
+
+/**
+ * Default maximum combined nesting depth of parenthesized groups and NOT
+ */
+const DEFAULT_MAX_DEPTH = 64;
+
+/**
  * Parser for Filtron queries
  */
 class Parser {
 	private lexer: Lexer;
 	private current: Token;
 	private nextToken: Token | null = null;
+	private depth = 0;
+	private readonly maxDepth: number;
 
-	constructor(input: string) {
+	constructor(input: string, maxLength: number, maxDepth: number) {
+		if (input.length > maxLength) {
+			throw new FiltronParseError(`Query exceeds maximum length of ${maxLength} characters`, 0);
+		}
+		this.maxDepth = maxDepth;
 		this.lexer = new Lexer(input);
 		this.current = this.lexer.next();
 	}
@@ -152,8 +169,15 @@ class Parser {
 	 */
 	private parseNotExpression(): ASTNode {
 		if (this.check("NOT")) {
+			if (++this.depth > this.maxDepth) {
+				throw new FiltronParseError(
+					`Query exceeds maximum nesting depth of ${this.maxDepth}`,
+					this.current.start,
+				);
+			}
 			this.advance();
 			const expression = this.parseNotExpression();
+			this.depth--;
 			return { type: "not", expression };
 		}
 
@@ -173,9 +197,16 @@ class Parser {
 
 		// Parenthesized expression
 		if (this.check("LPAREN")) {
+			if (++this.depth > this.maxDepth) {
+				throw new FiltronParseError(
+					`Query exceeds maximum nesting depth of ${this.maxDepth}`,
+					this.current.start,
+				);
+			}
 			this.advance();
 			const expr = this.parseOrExpression();
 			this.expect("RPAREN", "Expected closing parenthesis");
+			this.depth--;
 			return expr;
 		}
 
@@ -397,10 +428,15 @@ class Parser {
  * Parse a Filtron query string into an AST
  *
  * @param input - The query string to parse
+ * @param options - Optional parse limits
  * @returns The parsed AST
- * @throws FiltronParseError if the query is invalid
+ * @throws FiltronParseError if the query is invalid or exceeds a limit
  */
-export function parseQuery(input: string): ASTNode {
-	const parser = new Parser(input);
+export function parseQuery(input: string, options?: ParseOptions): ASTNode {
+	const parser = new Parser(
+		input,
+		options?.maxLength ?? DEFAULT_MAX_LENGTH,
+		options?.maxDepth ?? DEFAULT_MAX_DEPTH,
+	);
 	return parser.parse();
 }


### PR DESCRIPTION
### Why

Real-time API input with unbounded nesting recurses through the parser and every adapter; limits are a cheap guard against malicious queries.

### What

- `ParseOptions { maxLength?, maxDepth? }` on `parse()` and `parseOrThrow()`; defaults 10000 characters and 64 combined levels of parenthesized groups and NOT.
- Length is checked once before lexing (FiltronParseError at position 0); depth is a single counter touched only in the two branches that already recurse, with the error at the offending token's position.
- Boundary-exact tests (64 passes, 65 fails, with pinned positions), custom limits both directions, and README documentation.

### Notes

- `ParseOptions` lives in parser.ts and is type-imported by rd-parser.ts (erased at build; no runtime cycle). Flagging since it's a back-reference between the two files.
- Sibling groups do not accumulate depth: `(a) AND (b)` is depth 1.

Closes: #288 
