### PR TITLE
feat(core): move field validation to core

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -140,6 +140,18 @@ walk(ast, (node) => {
 // fields: ["age", "status"]
 ```
 
+### `validateFields(node: ASTNode, allowedFields: readonly string[]): void`
+
+Validates that every field referenced in an AST is in the allowlist. Throws an `Error` on the first disallowed field. Consumers like @filtron/js and @filtron/sql use this for their `allowedFields` option.
+
+```typescript
+import { parseOrThrow, validateFields } from "@filtron/core";
+
+const ast = parseOrThrow('password = "secret"');
+validateFields(ast, ["name", "age"]);
+// Error: Field "password" is not allowed. Allowed fields: name, age
+```
+
 ## Types
 
 All AST types are exported for building custom consumers:

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -148,8 +148,13 @@ Validates that every field referenced in an AST is in the allowlist. Throws an `
 import { parseOrThrow, validateFields } from "@filtron/core";
 
 const ast = parseOrThrow('password = "secret"');
+
+// Safe: an allowlist rejects fields the caller did not expose
 validateFields(ast, ["name", "age"]);
 // Error: Field "password" is not allowed. Allowed fields: name, age
+
+// Unsafe: skipping validation lets any field through to the adapter
+// toSQL(ast) would interpolate whatever field name the AST contains
 ```
 
 ## Types

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,9 @@ export type { ParseResult, ParseSuccess, ParseFailure } from "./parser";
 // AST walker
 export { walk } from "./walker";
 
+// AST field validation
+export { validateFields } from "./validate";
+
 // Lexer for tokenization
 export { Lexer } from "./lexer";
 export type {

--- a/packages/core/src/validate.test.ts
+++ b/packages/core/src/validate.test.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect } from "bun:test";
+import { parseOrThrow } from "./parser";
+import { validateFields } from "./validate";
+
+describe("validateFields()", () => {
+	test("passes when all fields are allowed", () => {
+		const ast = parseOrThrow('age > 18 AND status = "active"');
+		expect(() => validateFields(ast, ["age", "status"])).not.toThrow();
+	});
+
+	test("throws on a disallowed field with the exact message", () => {
+		const ast = parseOrThrow('password = "secret"');
+		expect(() => validateFields(ast, ["name", "age"])).toThrow(
+			'Field "password" is not allowed. Allowed fields: name, age',
+		);
+	});
+
+	test("validates fields nested under and/or/not", () => {
+		const ast = parseOrThrow("(a = 1 OR b = 2) AND NOT c?");
+		expect(() => validateFields(ast, ["a", "b", "c"])).not.toThrow();
+		expect(() => validateFields(ast, ["a", "b"])).toThrow(
+			'Field "c" is not allowed. Allowed fields: a, b',
+		);
+	});
+
+	test("throws on the first disallowed field in pre-order", () => {
+		const ast = parseOrThrow("a = 1 AND b = 2 AND c = 3");
+		expect(() => validateFields(ast, ["a"])).toThrow('Field "b" is not allowed. Allowed fields: a');
+	});
+
+	test("empty allowlist rejects any field", () => {
+		const ast = parseOrThrow("a = 1");
+		expect(() => validateFields(ast, [])).toThrow('Field "a" is not allowed. Allowed fields: ');
+	});
+});

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -1,0 +1,38 @@
+/**
+ * Field validation for Filtron AST
+ */
+
+import type { ASTNode } from "./types";
+import { walk } from "./walker";
+
+/**
+ * Validates that every field referenced in an AST is in the allowlist
+ *
+ * Walks the AST in pre-order and throws on the first field that is not
+ * in `allowedFields`. Useful for guarding hand-built ASTs and untrusted
+ * queries before generating filters or SQL.
+ *
+ * @param node - The AST node to validate
+ * @param allowedFields - Field names that are allowed to appear in the AST
+ * @throws Error if a field is not in the allowlist
+ *
+ * @example
+ * ```typescript
+ * import { parseOrThrow, validateFields } from "@filtron/core";
+ *
+ * const ast = parseOrThrow("password = \"hunter2\"");
+ * validateFields(ast, ["name", "age"]);
+ * // Error: Field "password" is not allowed. Allowed fields: name, age
+ * ```
+ */
+export function validateFields(node: ASTNode, allowedFields: readonly string[]): void {
+	const allowed = new Set(allowedFields);
+	walk(node, (current) => {
+		if ("field" in current && !allowed.has(current.field)) {
+			throw new Error(
+				`Field "${current.field}" is not allowed. Allowed fields: ${allowedFields.join(", ")}`,
+			);
+		}
+		return undefined;
+	});
+}

--- a/packages/js/src/filter.ts
+++ b/packages/js/src/filter.ts
@@ -3,6 +3,7 @@
  * Converts Filtron AST nodes to predicate functions for filtering arrays
  */
 
+import { validateFields } from "@filtron/core";
 import type {
 	ASTNode,
 	Value,
@@ -28,7 +29,8 @@ export interface FilterOptions {
 	/**
 	 * Allowed field names for filtering
 	 * If provided, only these fields can be used in queries
-	 * Throws an error if a query references a field not in this list
+	 * The whole AST is validated up front; throws an error if any field
+	 * is not in this list
 	 * @default undefined (all fields allowed)
 	 */
 	allowedFields?: string[];
@@ -82,7 +84,6 @@ export interface FilterOptions {
  * which lets generators emit specialized predicates without the indirect call
  */
 interface GeneratorState {
-	allowedFields?: Set<string>;
 	fieldAccessor?: (obj: Record<string, unknown>, field: string) => unknown;
 	caseInsensitive: boolean;
 	fieldMapping?: Record<string, string>;
@@ -119,8 +120,11 @@ export function toFilter<T extends Record<string, unknown> = Record<string, unkn
 	ast: ASTNode,
 	options: FilterOptions = {},
 ): FilterPredicate<T> {
+	if (options.allowedFields) {
+		validateFields(ast, options.allowedFields);
+	}
+
 	const state: GeneratorState = {
-		allowedFields: options.allowedFields ? new Set(options.allowedFields) : undefined,
 		fieldAccessor: options.fieldAccessor,
 		caseInsensitive: options.caseInsensitive ?? false,
 		fieldMapping: options.fieldMapping,
@@ -130,15 +134,9 @@ export function toFilter<T extends Record<string, unknown> = Record<string, unkn
 }
 
 /**
- * Validates that a field is allowed (if allowedFields is set) and
- * resolves it through fieldMapping if provided
+ * Resolves a field through fieldMapping if provided
  */
 function resolveField(field: string, state: GeneratorState): string {
-	if (state.allowedFields && !state.allowedFields.has(field)) {
-		throw new Error(
-			`Field "${field}" is not allowed. Allowed fields: ${[...state.allowedFields].join(", ")}`,
-		);
-	}
 	return state.fieldMapping ? (state.fieldMapping[field] ?? field) : field;
 }
 

--- a/packages/sql/README.md
+++ b/packages/sql/README.md
@@ -53,6 +53,7 @@ interface SQLResult {
 | `valueMapper`    | `(value: unknown) => unknown` | `undefined`  | Custom transform for `~` values (see below)   |
 | `likeMode`       | `"contains"` \| `"raw"`       | `"contains"` | How `~` builds its LIKE parameter (see below) |
 | `startIndex`     | `number`                      | `1`          | Starting index for numbered placeholders      |
+| `allowedFields`  | `string[]`                    | `undefined`  | Allowlist of field names (throws otherwise)   |
 
 #### Parameter styles
 
@@ -193,6 +194,21 @@ const { sql, params } = toSQL(result.ast);
 ```
 
 Never interpolate user input directly into SQL. Always use the `params` array with your database driver's parameterized query support.
+
+Field names are interpolated into the generated SQL. Queries that go through the parser restrict the field charset, but hand-built ASTs are unvalidated. Use `allowedFields` to guard those and add defense in depth:
+
+```typescript
+// Safe: only listed fields can reach the SQL string
+toSQL(ast, { allowedFields: ["name", "age", "status"] });
+
+// Unsafe: a hand-built AST can put anything in a field name
+toSQL({
+	type: "comparison",
+	field: 'password" = "" OR "1', // interpolated as-is
+	operator: "=",
+	value: { type: "string", value: "x" },
+});
+```
 
 LIKE patterns deserve the same care. The default `likeMode: "contains"` escapes `%`, `_` and `\` so user input cannot smuggle wildcards into the pattern:
 

--- a/packages/sql/src/converter.test.ts
+++ b/packages/sql/src/converter.test.ts
@@ -607,6 +607,45 @@ describe("SQL", () => {
 		});
 	});
 
+	describe("Allowed Fields", () => {
+		test("allows listed fields", () => {
+			const ast: ASTNode = {
+				type: "and",
+				children: [
+					{
+						type: "comparison",
+						field: "age",
+						operator: ">",
+						value: { type: "number", value: 18 },
+					},
+					{
+						type: "comparison",
+						field: "status",
+						operator: "=",
+						value: { type: "string", value: "active" },
+					},
+				],
+			};
+
+			const result = toSQL(ast, { allowedFields: ["age", "status"] });
+			expect(result.sql).toBe("(age > $1 AND status = $2)");
+			expect(result.params).toEqual([18, "active"]);
+		});
+
+		test("throws for unlisted field in a hand-built AST", () => {
+			const ast: ASTNode = {
+				type: "comparison",
+				field: 'password" = "" OR "1',
+				operator: "=",
+				value: { type: "string", value: "secret" },
+			};
+
+			expect(() => toSQL(ast, { allowedFields: ["age", "status"] })).toThrow(
+				'Field "password" = "" OR "1" is not allowed. Allowed fields: age, status',
+			);
+		});
+	});
+
 	describe("LIKE Value Mapping", () => {
 		test("default likeMode wraps LIKE values for contains matching", () => {
 			const ast: ASTNode = {

--- a/packages/sql/src/converter.ts
+++ b/packages/sql/src/converter.ts
@@ -3,6 +3,7 @@
  * Converts Filtron AST nodes to parameterized SQL WHERE clauses
  */
 
+import { validateFields } from "@filtron/core";
 import type {
 	ASTNode,
 	Value,
@@ -82,6 +83,17 @@ export interface SQLOptions {
 	 * @default 1
 	 */
 	startIndex?: number;
+
+	/**
+	 * Allowed field names for SQL generation
+	 * If provided, the whole AST is validated up front and toSQL throws
+	 * if any field is not in this list. Field names are interpolated into
+	 * the generated SQL; the parser's lexer restricts the field charset
+	 * for parsed queries, but hand-built ASTs are unvalidated, so an
+	 * allowlist guards those and adds defense in depth
+	 * @default undefined (all fields allowed)
+	 */
+	allowedFields?: string[];
 }
 
 /**
@@ -124,6 +136,10 @@ const NUMBERED_PLACEHOLDERS: string[] = Array.from({ length: 65 }, (_, i) => `$$
  * ```
  */
 export function toSQL(ast: ASTNode, options: SQLOptions = {}): SQLResult {
+	if (options.allowedFields) {
+		validateFields(ast, options.allowedFields);
+	}
+
 	const state: GeneratorState = {
 		params: [],
 		numbered: options.parameterStyle !== "question",


### PR DESCRIPTION
### Why

`allowedFields` existed only in @filtron/js, while @filtron/sql interpolates field names into the clause — safe for parsed queries via the lexer charset, but unvalidated for hand-built ASTs.

### What

- `validateFields(node, allowedFields)` in @filtron/core, built on `walk()`: throws on the first disallowed field with the exact message @filtron/js used, so js behavior is unchanged.
- @filtron/js validates up front in `toFilter` and drops the per-node check from field resolution (one fewer branch on the compile path).
- @filtron/sql gains `allowedFields?: string[]`; the test suite pins that an injection-shaped field name in a hand-built AST is rejected before reaching SQL text. sql README documents the option with safe/unsafe examples.

Closes: #289