### PR TITLE
chore: scope switch exhaustiveness checks to braced default clauses

### DIFF
--- a/packages/js/src/filter.ts
+++ b/packages/js/src/filter.ts
@@ -161,10 +161,11 @@ function generateFilter(
 			return generateExists(node, state);
 		case "booleanField":
 			return generateBooleanField(node, state);
-		default:
+		default: {
 			// TypeScript exhaustiveness check
 			const _exhaustive: never = node;
 			throw new Error(`Unknown node type: ${(node as ASTNode).type}`);
+		}
 	}
 }
 
@@ -414,9 +415,10 @@ function generateComparison(
 				return typeof fieldValue === "number" && fieldValue <= targetValue;
 			};
 
-		default:
+		default: {
 			const _exhaustive: never = node.operator;
 			throw new Error(`Unknown operator: ${_exhaustive as string}`);
+		}
 	}
 }
 
@@ -649,9 +651,10 @@ function extractValue(value: Value): string | number | boolean {
 		case "identifier":
 			// Identifiers are treated as strings
 			return value.value;
-		default:
+		default: {
 			const _exhaustive: never = value;
 			throw new Error(`Unknown value type: ${(value as Value).type}`);
+		}
 	}
 }
 

--- a/packages/sql/src/converter.ts
+++ b/packages/sql/src/converter.ts
@@ -174,10 +174,11 @@ function generateSQL(node: ASTNode, state: GeneratorState): string {
 			return generateExists(node, state);
 		case "booleanField":
 			return generateBooleanField(node, state);
-		default:
+		default: {
 			// TypeScript exhaustiveness check
 			const _exhaustive: never = node;
 			throw new Error(`Unknown node type: ${(node as ASTNode).type}`);
+		}
 	}
 }
 
@@ -306,9 +307,10 @@ function mapComparisonOperator(operator: ComparisonOperator): string {
 			return "<";
 		case "<=":
 			return "<=";
-		default:
+		default: {
 			const _exhaustive: never = operator;
 			throw new Error(`Unknown operator: ${operator as string}`);
+		}
 	}
 }
 
@@ -329,9 +331,10 @@ function extractValue(value: Value): string | number | boolean {
 		case "identifier":
 			// Identifiers are treated as strings in SQL context
 			return value.value;
-		default:
+		default: {
 			const _exhaustive: never = value;
 			throw new Error(`Unknown value type: ${(value as Value).type}`);
+		}
 	}
 }
 


### PR DESCRIPTION
### Why

Unbraced default clauses scope their `const _exhaustive` declaration to the whole switch instead of the clause. The walker got this treatment during review; this normalizes the six remaining sites.

### What

`default:` becomes `default: { ... }` in the node-type, operator, and value switches of both adapters (three sites each in @filtron/js and @filtron/sql).

Closes: https://github.com/jbergstroem/filtron/issues/303
Refs: https://github.com/jbergstroem/filtron/issues/302