### PR TITLE
feat(core): add temporal values using the `@` sigil

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,8 +87,10 @@ PrimaryExpression = '(' OrExpression ')' | '-' FieldName | FieldExpression
 FieldExpression = FieldName ('?' | EXISTS | ComparisonOp Value | OneOfOp '[' Values ']')?
 FieldName       = IDENT ('.' IDENT)*
 Values          = Value (',' Value)*
-Value           = STRING | NUMBER | BOOLEAN | DottedIdent | Range
+Value           = STRING | NUMBER | BOOLEAN | DottedIdent | Range | Temporal
 Range           = NUMBER '..' NUMBER
+Temporal        = '@' Point ('..' Point)?
+Point           = Date | 'now' (('+' | '-') NUMBER Unit)?
 ```
 
 ## Checklist: modifying parser

--- a/packages/conformance/src/index.ts
+++ b/packages/conformance/src/index.ts
@@ -37,6 +37,7 @@ export interface ConformanceCase {
 export const dataset: ConformanceRecord[] = [
 	{
 		id: 1,
+		created: "2024-01-15",
 		name: "Alice Johnson",
 		age: 25,
 		score: 4.5,
@@ -49,6 +50,7 @@ export const dataset: ConformanceRecord[] = [
 	},
 	{
 		id: 2,
+		created: "2024-02-20",
 		name: "Bob Smith",
 		age: 17,
 		score: 2,
@@ -61,6 +63,7 @@ export const dataset: ConformanceRecord[] = [
 	},
 	{
 		id: 3,
+		created: "2024-03-25",
 		name: "Charlie Brown",
 		age: 30,
 		score: 3.25,
@@ -72,6 +75,7 @@ export const dataset: ConformanceRecord[] = [
 	},
 	{
 		id: 4,
+		created: "2024-04-30",
 		name: "Dana White",
 		age: 42,
 		score: -1.5,
@@ -84,6 +88,7 @@ export const dataset: ConformanceRecord[] = [
 	},
 	{
 		id: 5,
+		created: "2024-05-05",
 		name: "Eve Adams",
 		age: 18,
 		score: 0,
@@ -96,6 +101,7 @@ export const dataset: ConformanceRecord[] = [
 	},
 	{
 		id: 6,
+		created: "2024-06-10",
 		name: "frank o'neil",
 		age: 65,
 		score: 5,
@@ -108,6 +114,7 @@ export const dataset: ConformanceRecord[] = [
 	},
 	{
 		id: 7,
+		created: "2024-07-15",
 		name: "Grace_Hopper",
 		age: 85,
 		score: 10.75,
@@ -121,6 +128,7 @@ export const dataset: ConformanceRecord[] = [
 	},
 	{
 		id: 8,
+		created: "2024-08-20",
 		name: "Hank 100%",
 		age: 33,
 		score: 3,
@@ -212,6 +220,21 @@ export const cases: ConformanceCase[] = [
 		sql: "age NOT BETWEEN $1 AND $2",
 		params: [18, 30],
 		notes: "Ranges are values (#287); != means outside the interval and maps to NOT BETWEEN.",
+	},
+	{
+		name: "temporal-point",
+		query: "created > @2024-06-01",
+		matches: [6, 7, 8],
+		sql: "created > $1",
+		params: ["2024-06-01"],
+		notes: "Dates compare as epoch milliseconds in js; sql passes the ISO string as a parameter.",
+	},
+	{
+		name: "temporal-range",
+		query: "created = @2024-03-01..2024-06-30",
+		matches: [3, 4, 5, 6],
+		sql: "created BETWEEN $1 AND $2",
+		params: ["2024-03-01", "2024-06-30"],
 	},
 	{
 		name: "one-of-small",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -229,7 +229,7 @@ import type { Token, TokenType, StringToken, NumberToken, BooleanToken } from "@
 
 Temporal literals start with `@` and are either a point or a range: `created > @2024-06-01`, `updated > @now-1h`, `deployed = @2024-06-01..2024-06-30`, `created = @now-7d..now`. Absolute dates produce `{ type: "date", value }`; `@now` with an optional signed offset (`s`, `m`, `h`, `d`, `w`, `M`, `y`) produces an inert `{ type: "now", offset }` that adapters reject until it is resolved to a date. Points work with every comparison operator except `~`; temporal ranges follow the same `=`, `:`, `!=` rule as numeric ranges.
 
-Ranges are values, not nodes: `age = 18..65` produces a comparison whose value is `{ type: "range", min: 18, max: 65 }`. Ranges work with `=`, `:` and `!=` (outside the interval) and are rejected inside arrays.
+Ranges are values, not nodes, discriminated by `kind`: `age = 18..65` produces a comparison whose value is `{ type: "range", kind: "number", min: 18, max: 65 }`, and `deployed = @2024-06-01..2024-06-30` produces `{ type: "range", kind: "temporal", min: { type: "date", value: "2024-06-01" }, max: { type: "date", value: "2024-06-30" } }`. Hand-built range values must set `kind`. Ranges work with `=`, `:` and `!=` (outside the interval) and are rejected inside arrays.
 
 Chains of the same operator are flat: `a AND b AND c` produces a single `and` node with three children, never nested pairs.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -86,6 +86,7 @@ parse("user.profile.age >= 18");
 | `?`, `EXISTS`        | Field exists  | `email?`              |
 | `-`                  | Field missing | `-email`              |
 | `..`                 | Range value   | `age = 18..65`        |
+| `@`                  | Temporal      | `created > @now-7d`   |
 | `: [...]`            | One of        | `status : ["a", "b"]` |
 | `AND`, `OR`, `NOT`   | Boolean logic | `a AND (b OR c)`      |
 
@@ -225,6 +226,8 @@ import type { Token, TokenType, StringToken, NumberToken, BooleanToken } from "@
 | `exists`       | `field`, `negated`           | `email?`, `-email`    |
 | `booleanField` | `field`                      | `verified`            |
 | `oneOf`        | `field`, `values`, `negated` | `status : ["a", "b"]` |
+
+Temporal literals start with `@` and are either a point or a range: `created > @2024-06-01`, `updated > @now-1h`, `deployed = @2024-06-01..2024-06-30`, `created = @now-7d..now`. Absolute dates produce `{ type: "date", value }`; `@now` with an optional signed offset (`s`, `m`, `h`, `d`, `w`, `M`, `y`) produces an inert `{ type: "now", offset }` that adapters reject until it is resolved to a date. Points work with every comparison operator except `~`; temporal ranges follow the same `=`, `:`, `!=` rule as numeric ranges.
 
 Ranges are values, not nodes: `age = 18..65` produces a comparison whose value is `{ type: "range", min: 18, max: 65 }`. Ranges work with `=`, `:` and `!=` (outside the interval) and are rejected inside arrays.
 

--- a/packages/core/examples/query-syntax.ts
+++ b/packages/core/examples/query-syntax.ts
@@ -28,6 +28,11 @@ parseOrThrow('status !: ["deleted", "banned"]');
 parseOrThrow("age = 18..65");
 parseOrThrow("age != 18..65"); // outside the interval
 
+// Temporal values: absolute dates and now-relative points
+parseOrThrow("created > @2024-06-01");
+parseOrThrow("updated > @now-1h"); // resolve now-relative values before filtering
+parseOrThrow("deployed = @2024-06-01..2024-06-30");
+
 // Logical operators: AND, OR, NOT
 parseOrThrow('active AND role = "admin"');
 parseOrThrow('role = "admin" OR role = "moderator"');

--- a/packages/core/filtron.tmLanguage.json
+++ b/packages/core/filtron.tmLanguage.json
@@ -27,7 +27,7 @@
 			"name": "keyword.control.filtron"
 		},
 		"operators": {
-			"match": "(>=|<=|!=|!:|:|=|>|<|~|\\?|\\.\\.|-(?=[A-Za-z_]))",
+			"match": "(>=|<=|!=|!:|:|=|>|<|~|\\?|\\.\\.|@|-(?=[A-Za-z_]))",
 			"name": "keyword.operator.filtron"
 		},
 		"strings": {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -49,4 +49,11 @@ export type {
 	NumberValue,
 	BooleanValue,
 	IdentifierValue,
+	RangeValue,
+	NumberRangeValue,
+	TemporalRangeValue,
+	DateValue,
+	NowValue,
+	TemporalPoint,
+	DurationUnit,
 } from "./types";

--- a/packages/core/src/lexer.test.ts
+++ b/packages/core/src/lexer.test.ts
@@ -303,15 +303,132 @@ describe("Lexer", () => {
 		});
 	});
 
+	describe("Temporal Literals", () => {
+		test("bare now", () => {
+			const tokens = tokenize("@now");
+			expect(tokens[0]).toEqual({
+				type: "TEMPORAL",
+				value: { type: "now", offset: null },
+				start: 0,
+				end: 4,
+			});
+		});
+
+		test("now with negative offset", () => {
+			const tokens = tokenize("@now-7d");
+			expect(tokens[0]).toEqual({
+				type: "TEMPORAL",
+				value: { type: "now", offset: { amount: -7, unit: "d" } },
+				start: 0,
+				end: 7,
+			});
+		});
+
+		test("now with positive offset", () => {
+			const tokens = tokenize("@now+2h");
+			expect(tokens[0]).toEqual({
+				type: "TEMPORAL",
+				value: { type: "now", offset: { amount: 2, unit: "h" } },
+				start: 0,
+				end: 7,
+			});
+		});
+
+		test.each(["s", "m", "h", "d", "w", "M", "y"])("duration unit %s", (unit) => {
+			const tokens = tokenize(`@now-1${unit}`);
+			expect(tokens[0]).toEqual({
+				type: "TEMPORAL",
+				value: { type: "now", offset: { amount: -1, unit } },
+				start: 0,
+				end: 7,
+			});
+		});
+
+		test("date only", () => {
+			const tokens = tokenize("@2024-06-01");
+			expect(tokens[0]).toEqual({
+				type: "TEMPORAL",
+				value: { type: "date", value: "2024-06-01" },
+				start: 0,
+				end: 11,
+			});
+		});
+
+		test("datetime with zone forms", () => {
+			expect(tokenize("@2024-06-01T14:30:00Z")[0].type).toBe("TEMPORAL");
+			expect(tokenize("@2024-06-01T14:30:00+02:00")[0].type).toBe("TEMPORAL");
+			expect(tokenize("@2024-06-01T14:30:00.123Z")[0].type).toBe("TEMPORAL");
+			expect(tokenize("@2024-06-01T14:30:00")[0].type).toBe("TEMPORAL");
+		});
+
+		test("temporal range with two dates", () => {
+			const tokens = tokenize("@2024-06-01..2024-06-30");
+			expect(tokens[0]).toEqual({
+				type: "TEMPORAL",
+				value: {
+					type: "range",
+					kind: "temporal",
+					min: { type: "date", value: "2024-06-01" },
+					max: { type: "date", value: "2024-06-30" },
+				},
+				start: 0,
+				end: 23,
+			});
+		});
+
+		test("temporal range mixing now and dates", () => {
+			const value = tokenize("@now-7d..now")[0];
+			expect(value).toEqual({
+				type: "TEMPORAL",
+				value: {
+					type: "range",
+					kind: "temporal",
+					min: { type: "now", offset: { amount: -7, unit: "d" } },
+					max: { type: "now", offset: null },
+				},
+				start: 0,
+				end: 12,
+			});
+			expect(tokenize("@2024-06-01..now")[0].type).toBe("TEMPORAL");
+		});
+
+		test("invalid calendar dates throw", () => {
+			expect(() => tokenize("@2024-02-30")).toThrow("Invalid date: 2024-02-30");
+			expect(() => tokenize("@2024-13-01")).toThrow("Invalid date: 2024-13-01");
+		});
+
+		test("malformed temporals throw", () => {
+			expect(() => tokenize("@")).toThrow("Expected a date or now after '@'");
+			expect(() => tokenize("@foo")).toThrow("Expected a date or now after '@'");
+			expect(() => tokenize("@2024-06")).toThrow("Invalid date in temporal value");
+			expect(() => tokenize("@now-")).toThrow("Expected a number after the offset sign");
+			expect(() => tokenize("@now-7x")).toThrow("Expected a duration unit");
+			expect(() => tokenize("@now-7")).toThrow("Expected a duration unit");
+			expect(() => tokenize("@2024-06-01x")).toThrow("Unexpected character in temporal value");
+			expect(() => tokenize("@now7")).toThrow("Unexpected character in temporal value");
+			expect(() => tokenize("@2024-06-01..")).toThrow("Expected a date or now after '..'");
+			expect(() => tokenize("@2024-06-01..@2024-06-30")).toThrow(
+				"Expected a date or now after '..'",
+			);
+		});
+
+		test("inverted absolute range throws", () => {
+			expect(() => tokenize("@2024-06-30..2024-06-01")).toThrow(
+				"Range min (2024-06-30) must not exceed max (2024-06-01)",
+			);
+			expect(tokenize("@2024-06-01..2024-06-01")[0].type).toBe("TEMPORAL");
+		});
+	});
+
 	describe("Error Handling", () => {
 		test("unexpected character", () => {
-			const lexer = new Lexer("@");
+			const lexer = new Lexer("%");
 			expect(() => lexer.next()).toThrow(FiltronParseError);
-			expect(() => lexer.next()).toThrow("Unexpected character: '@'");
+			expect(() => lexer.next()).toThrow("Unexpected character: '%'");
 		});
 
 		test("error includes position", () => {
-			const lexer = new Lexer("valid @");
+			const lexer = new Lexer("valid %");
 			lexer.next(); // consume 'valid'
 			try {
 				lexer.next();

--- a/packages/core/src/lexer.test.ts
+++ b/packages/core/src/lexer.test.ts
@@ -412,6 +412,24 @@ describe("Lexer", () => {
 			);
 		});
 
+		test("invalid timezone offsets throw", () => {
+			expect(() => tokenize("@2024-06-01T12:00:00+99:99")).toThrow("Invalid date");
+			expect(() => tokenize("@2024-06-01T12:00:00+02:70")).toThrow("Invalid date");
+			expect(tokenize("@2024-06-01T12:00:00+23:59")[0].type).toBe("TEMPORAL");
+			expect(tokenize("@2024-06-01T12:00:00-05:00")[0].type).toBe("TEMPORAL");
+		});
+
+		test("inverted zoned datetime range throws", () => {
+			expect(() => tokenize("@2024-06-02T00:00:00Z..2024-06-01T00:00:00Z")).toThrow(
+				"Range min (2024-06-02T00:00:00Z) must not exceed max (2024-06-01T00:00:00Z)",
+			);
+			expect(() => tokenize("@2024-06-02T00:00:00+02:00..2024-06-01T00:00:00Z")).toThrow(
+				FiltronParseError,
+			);
+			// Naive datetimes are timezone-dependent, so ordering defers to resolution
+			expect(tokenize("@2024-06-02T00:00:00..2024-06-01T00:00:00")[0].type).toBe("TEMPORAL");
+		});
+
 		test("inverted absolute range throws", () => {
 			expect(() => tokenize("@2024-06-30..2024-06-01")).toThrow(
 				"Range min (2024-06-30) must not exceed max (2024-06-01)",

--- a/packages/core/src/lexer.ts
+++ b/packages/core/src/lexer.ts
@@ -3,7 +3,7 @@
  */
 
 import { FiltronParseError } from "./errors";
-import type { DateValue, DurationUnit, NowValue, TemporalPoint, TemporalRangeValue } from "./types";
+import type { DateValue, NowValue, TemporalPoint, TemporalRangeValue } from "./types";
 
 /**
  * Token types produced by the lexer

--- a/packages/core/src/lexer.ts
+++ b/packages/core/src/lexer.ts
@@ -3,6 +3,7 @@
  */
 
 import { FiltronParseError } from "./errors";
+import type { DateValue, DurationUnit, NowValue, TemporalPoint, TemporalRangeValue } from "./types";
 
 /**
  * Token types produced by the lexer
@@ -35,6 +36,7 @@ export type TokenType =
 	| "STRING"
 	| "NUMBER"
 	| "IDENT"
+	| "TEMPORAL"
 	| "EOF";
 
 /** Base token properties */
@@ -89,10 +91,16 @@ export interface BooleanToken extends TokenBase {
 	value: boolean;
 }
 
+/** Temporal literal tokens: the scanner builds the finished value */
+export interface TemporalToken extends TokenBase {
+	type: "TEMPORAL";
+	value: DateValue | NowValue | TemporalRangeValue;
+}
+
 /**
  * Discriminated union of all token types for proper type narrowing
  */
-export type Token = StringToken | NumberToken | BooleanToken | SymbolToken;
+export type Token = StringToken | NumberToken | BooleanToken | TemporalToken | SymbolToken;
 
 // Character codes
 const C = {
@@ -115,7 +123,9 @@ const C = {
 	Equals: 61,
 	GreaterThan: 62,
 	Question: 63,
+	At: 64,
 	UpperA: 65,
+	Plus: 43,
 	UpperZ: 90,
 	LBracket: 91,
 	Backslash: 92,
@@ -151,6 +161,7 @@ const CLS_QUESTION = 14;
 const CLS_EQ = 15;
 const CLS_TILDE = 16;
 const CLS_COLON = 17;
+const CLS_AT = 18;
 
 const CHAR_CLASS: Uint8Array = (() => {
 	const table = new Uint8Array(128);
@@ -173,6 +184,7 @@ const CHAR_CLASS: Uint8Array = (() => {
 	table[C.Equals] = CLS_EQ;
 	table[C.Tilde] = CLS_TILDE;
 	table[C.Colon] = CLS_COLON;
+	table[C.At] = CLS_AT;
 	return table;
 })();
 
@@ -430,6 +442,217 @@ export class Lexer {
 	}
 
 	/**
+	 * Scan exactly n digits starting at pos, returning the position after them
+	 */
+	private scanDigits(pos: number, n: number): number {
+		for (let i = 0; i < n; i++) {
+			const code = pos < this.length ? this.input.charCodeAt(pos) : 0;
+			if (code < C.Zero || code > C.Nine) {
+				throw new FiltronParseError("Invalid date in temporal value", pos);
+			}
+			pos++;
+		}
+		return pos;
+	}
+
+	/**
+	 * Read n already-validated digits as a number
+	 */
+	private digitsValue(pos: number, n: number): number {
+		let value = 0;
+		for (let i = 0; i < n; i++) {
+			value = value * 10 + (this.input.charCodeAt(pos + i) - C.Zero);
+		}
+		return value;
+	}
+
+	/**
+	 * Scan a single expected character, returning the position after it
+	 */
+	private scanChar(pos: number, expected: number): number {
+		if (pos >= this.length || this.input.charCodeAt(pos) !== expected) {
+			throw new FiltronParseError("Invalid date in temporal value", pos);
+		}
+		return pos + 1;
+	}
+
+	/**
+	 * A temporal literal must end at a token boundary
+	 */
+	private assertTemporalBoundary(): void {
+		if (this.pos < this.length) {
+			const code = this.input.charCodeAt(this.pos);
+			if (code < 128) {
+				const cls = CHAR_CLASS[code];
+				if (cls === CLS_IDENT || cls === CLS_DIGIT) {
+					throw new FiltronParseError("Unexpected character in temporal value", this.pos);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Read one temporal point: an ISO 8601 date, or now with an
+	 * optional signed offset
+	 */
+	private readTemporalPoint(context: string): TemporalPoint {
+		const input = this.input;
+		const length = this.length;
+		const start = this.pos;
+		const code = start < length ? input.charCodeAt(start) : 0;
+
+		// now, optionally followed by +N<unit> or -N<unit>
+		if (code === 110) {
+			if (
+				start + 2 >= length ||
+				input.charCodeAt(start + 1) !== 111 ||
+				input.charCodeAt(start + 2) !== 119
+			) {
+				throw new FiltronParseError(`Expected a date or now ${context}`, start);
+			}
+			this.pos = start + 3;
+
+			let offset: NowValue["offset"] = null;
+			const signCode = this.pos < length ? input.charCodeAt(this.pos) : 0;
+			if (signCode === C.Minus || signCode === C.Plus) {
+				this.pos++;
+				let amount = 0;
+				let digits = 0;
+				while (this.pos < length) {
+					const digit = input.charCodeAt(this.pos);
+					if (digit < C.Zero || digit > C.Nine) break;
+					amount = amount * 10 + (digit - C.Zero);
+					digits++;
+					this.pos++;
+				}
+				if (digits === 0) {
+					throw new FiltronParseError("Expected a number after the offset sign", this.pos);
+				}
+				const unit = this.pos < length ? input[this.pos] : "";
+				if (
+					unit !== "s" &&
+					unit !== "m" &&
+					unit !== "h" &&
+					unit !== "d" &&
+					unit !== "w" &&
+					unit !== "M" &&
+					unit !== "y"
+				) {
+					throw new FiltronParseError("Expected a duration unit (s, m, h, d, w, M, y)", this.pos);
+				}
+				this.pos++;
+				offset = { amount: signCode === C.Minus ? -amount : amount, unit };
+			}
+
+			this.assertTemporalBoundary();
+			return { type: "now", offset };
+		}
+
+		// ISO 8601 date: YYYY-MM-DD, optional THH:MM:SS(.mmm)?(Z|+HH:MM|-HH:MM)?
+		if (code >= C.Zero && code <= C.Nine) {
+			let pos = this.scanDigits(start, 4);
+			pos = this.scanChar(pos, C.Minus);
+			pos = this.scanDigits(pos, 2);
+			pos = this.scanChar(pos, C.Minus);
+			pos = this.scanDigits(pos, 2);
+
+			if (pos < length && input.charCodeAt(pos) === 84) {
+				pos = this.scanDigits(pos + 1, 2);
+				pos = this.scanChar(pos, C.Colon);
+				pos = this.scanDigits(pos, 2);
+				pos = this.scanChar(pos, C.Colon);
+				pos = this.scanDigits(pos, 2);
+
+				if (pos < length && input.charCodeAt(pos) === C.Dot) {
+					pos = this.scanDigits(pos + 1, 1);
+					for (let i = 0; i < 2 && pos < length; i++) {
+						const digit = input.charCodeAt(pos);
+						if (digit < C.Zero || digit > C.Nine) break;
+						pos++;
+					}
+				}
+
+				const zone = pos < length ? input.charCodeAt(pos) : 0;
+				if (zone === 90) {
+					pos++;
+				} else if (zone === C.Plus || zone === C.Minus) {
+					pos = this.scanDigits(pos + 1, 2);
+					pos = this.scanChar(pos, C.Colon);
+					pos = this.scanDigits(pos, 2);
+				}
+			}
+
+			const value = input.slice(start, pos);
+			const year = this.digitsValue(start, 4);
+			const month = this.digitsValue(start + 5, 2);
+			const day = this.digitsValue(start + 8, 2);
+			const leap = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+			const daysInMonth = [31, leap ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+			let valid = month >= 1 && month <= 12 && day >= 1 && day <= daysInMonth[month - 1];
+			if (valid && pos > start + 10 && input.charCodeAt(start + 10) === 84) {
+				const hour = this.digitsValue(start + 11, 2);
+				const minute = this.digitsValue(start + 14, 2);
+				const second = this.digitsValue(start + 17, 2);
+				valid = hour <= 23 && minute <= 59 && second <= 59;
+			}
+			if (!valid) {
+				throw new FiltronParseError(`Invalid date: ${value}`, start);
+			}
+			this.pos = pos;
+			this.assertTemporalBoundary();
+			return { type: "date", value };
+		}
+
+		throw new FiltronParseError(`Expected a date or now ${context}`, start);
+	}
+
+	/**
+	 * Read a temporal literal: '@' followed by a point, optionally
+	 * '..' and a second point (no second '@')
+	 */
+	private readTemporal(): Token {
+		const start = this.pos;
+		this.pos = start + 1; // consume '@'
+
+		const min = this.readTemporalPoint("after '@'");
+
+		const input = this.input;
+		if (
+			this.pos + 1 < this.length &&
+			input.charCodeAt(this.pos) === C.Dot &&
+			input.charCodeAt(this.pos + 1) === C.Dot
+		) {
+			this.pos += 2;
+			const max = this.readTemporalPoint("after '..'");
+
+			// Ordering is only checked where it is timezone-independent:
+			// date-only bounds compare lexicographically. Bounds with times
+			// or now offsets are left to resolution
+			if (
+				min.type === "date" &&
+				max.type === "date" &&
+				min.value.length === 10 &&
+				max.value.length === 10 &&
+				min.value > max.value
+			) {
+				throw new FiltronParseError(
+					`Range min (${min.value}) must not exceed max (${max.value})`,
+					start,
+				);
+			}
+
+			return {
+				type: "TEMPORAL",
+				value: { type: "range", kind: "temporal", min, max },
+				start,
+				end: this.pos,
+			};
+		}
+
+		return { type: "TEMPORAL", value: min, start, end: this.pos };
+	}
+
+	/**
 	 * Get the next token
 	 */
 	next(): Token {
@@ -494,6 +717,8 @@ export class Lexer {
 			case CLS_COLON:
 				this.pos = pos + 1;
 				return { type: "COLON", start: pos, end: pos + 1 };
+			case CLS_AT:
+				return this.readTemporal();
 			case CLS_BANG: {
 				const nextCode = pos + 1 < length ? input.charCodeAt(pos + 1) : 0;
 				if (nextCode === C.Equals) {

--- a/packages/core/src/lexer.ts
+++ b/packages/core/src/lexer.ts
@@ -189,6 +189,22 @@ const CHAR_CLASS: Uint8Array = (() => {
 })();
 
 /**
+ * A calendar-validated ISO string is a fixed instant when it is
+ * date-only (UTC midnight per ISO 8601) or carries an explicit zone;
+ * naive datetimes depend on the runtime timezone
+ */
+function isUnambiguousInstant(value: string): boolean {
+	if (value.length === 10) {
+		return true;
+	}
+	if (value.endsWith("Z")) {
+		return true;
+	}
+	const sign = value.charAt(value.length - 6);
+	return sign === "+" || sign === "-";
+}
+
+/**
  * Lexer for tokenizing Filtron query strings
  */
 export class Lexer {
@@ -563,7 +579,14 @@ export class Lexer {
 				pos = this.scanChar(pos, C.Colon);
 				pos = this.scanDigits(pos, 2);
 
-				if (pos < length && input.charCodeAt(pos) === C.Dot) {
+				// Milliseconds need a digit after the dot, so a range's '..'
+				// is never mistaken for a fraction separator
+				if (
+					pos + 1 < length &&
+					input.charCodeAt(pos) === C.Dot &&
+					input.charCodeAt(pos + 1) >= C.Zero &&
+					input.charCodeAt(pos + 1) <= C.Nine
+				) {
 					pos = this.scanDigits(pos + 1, 1);
 					for (let i = 0; i < 2 && pos < length; i++) {
 						const digit = input.charCodeAt(pos);
@@ -576,9 +599,14 @@ export class Lexer {
 				if (zone === 90) {
 					pos++;
 				} else if (zone === C.Plus || zone === C.Minus) {
+					const zoneHourPos = pos + 1;
 					pos = this.scanDigits(pos + 1, 2);
 					pos = this.scanChar(pos, C.Colon);
+					const zoneMinutePos = pos;
 					pos = this.scanDigits(pos, 2);
+					if (this.digitsValue(zoneHourPos, 2) > 23 || this.digitsValue(zoneMinutePos, 2) > 59) {
+						throw new FiltronParseError(`Invalid date: ${input.slice(start, pos)}`, start);
+					}
 				}
 			}
 
@@ -626,14 +654,14 @@ export class Lexer {
 			const max = this.readTemporalPoint("after '..'");
 
 			// Ordering is only checked where it is timezone-independent:
-			// date-only bounds compare lexicographically. Bounds with times
-			// or now offsets are left to resolution
+			// date-only bounds (UTC midnight) and zoned datetimes are fixed
+			// instants. Naive datetimes and now offsets defer to resolution
 			if (
 				min.type === "date" &&
 				max.type === "date" &&
-				min.value.length === 10 &&
-				max.value.length === 10 &&
-				min.value > max.value
+				isUnambiguousInstant(min.value) &&
+				isUnambiguousInstant(max.value) &&
+				Date.parse(min.value) > Date.parse(max.value)
 			) {
 				throw new FiltronParseError(
 					`Range min (${min.value}) must not exceed max (${max.value})`,

--- a/packages/core/src/parser.test.ts
+++ b/packages/core/src/parser.test.ts
@@ -58,7 +58,7 @@ describe("Parser API", () => {
 		});
 
 		test("returns error result for unexpected characters", () => {
-			const result = parse("age @ 18");
+			const result = parse("age % 18");
 			expect(result.success).toBe(false);
 			if (!result.success) {
 				expect(result.message).toContain("Unexpected character");

--- a/packages/core/src/rd-parser.test.ts
+++ b/packages/core/src/rd-parser.test.ts
@@ -195,29 +195,29 @@ describe("RD Parser", () => {
 			expect(ast.type).toBe("comparison");
 			expect(ast.field).toBe("age");
 			expect(ast.operator).toBe("=");
-			expect(ast.value).toEqual({ type: "range", min: 18, max: 65 });
+			expect(ast.value).toEqual({ type: "range", kind: "number", min: 18, max: 65 });
 		});
 
 		test("float range", () => {
 			const ast = parseQuery("score = 0.0..100.0") as ComparisonExpression;
-			expect(ast.value).toEqual({ type: "range", min: 0, max: 100 });
+			expect(ast.value).toEqual({ type: "range", kind: "number", min: 0, max: 100 });
 		});
 
 		test("negative number range", () => {
 			const ast = parseQuery("temperature = -10..30") as ComparisonExpression;
-			expect(ast.value).toEqual({ type: "range", min: -10, max: 30 });
+			expect(ast.value).toEqual({ type: "range", kind: "number", min: -10, max: 30 });
 		});
 
 		test("range with colon operator", () => {
 			const ast = parseQuery("age : 18..65") as ComparisonExpression;
 			expect(ast.operator).toBe(":");
-			expect(ast.value).toEqual({ type: "range", min: 18, max: 65 });
+			expect(ast.value).toEqual({ type: "range", kind: "number", min: 18, max: 65 });
 		});
 
 		test("range with not-equals operator", () => {
 			const ast = parseQuery("age != 18..65") as ComparisonExpression;
 			expect(ast.operator).toBe("!=");
-			expect(ast.value).toEqual({ type: "range", min: 18, max: 65 });
+			expect(ast.value).toEqual({ type: "range", kind: "number", min: 18, max: 65 });
 		});
 
 		test("range with an ordering operator is an error", () => {
@@ -239,6 +239,58 @@ describe("RD Parser", () => {
 
 		test("incomplete range is an error", () => {
 			expect(() => parseQuery("age = 18..")).toThrow("Expected number after '..'");
+		});
+	});
+
+	describe("Temporal Values", () => {
+		test("date point with comparison operators", () => {
+			const ast = parseQuery("created > @2024-06-01") as ComparisonExpression;
+			expect(ast.operator).toBe(">");
+			expect(ast.value).toEqual({ type: "date", value: "2024-06-01" });
+		});
+
+		test("now point with offset", () => {
+			const ast = parseQuery("updated >= @now-7d") as ComparisonExpression;
+			expect(ast.value).toEqual({ type: "now", offset: { amount: -7, unit: "d" } });
+		});
+
+		test("temporal range", () => {
+			const ast = parseQuery("created = @2024-06-01..2024-06-30") as ComparisonExpression;
+			expect(ast.value).toEqual({
+				type: "range",
+				kind: "temporal",
+				min: { type: "date", value: "2024-06-01" },
+				max: { type: "date", value: "2024-06-30" },
+			});
+		});
+
+		test("temporal range with an ordering operator is an error", () => {
+			expect(() => parseQuery("created > @2024-06-01..2024-06-30")).toThrow(
+				"Range values require the =, : or != operator",
+			);
+		});
+
+		test("temporal point with the contains operator is an error", () => {
+			expect(() => parseQuery("created ~ @2024-06-01")).toThrow(
+				"Temporal values cannot be used with the ~ operator",
+			);
+			expect(() => parseQuery("created ~ @now")).toThrow(FiltronParseError);
+		});
+
+		test("temporal values inside arrays are an error", () => {
+			expect(() => parseQuery("created : [@2024-06-01]")).toThrow(
+				"Temporal values are not allowed in arrays",
+			);
+			expect(() => parseQuery("created : [1, @now]")).toThrow(FiltronParseError);
+		});
+
+		test("temporal points compose with boolean logic", () => {
+			const ast = parseQuery('status = "active" AND created > @now-1w') as AndExpression;
+			expect(ast.type).toBe("and");
+			expect((ast.children[1] as ComparisonExpression).value).toEqual({
+				type: "now",
+				offset: { amount: -1, unit: "w" },
+			});
 		});
 	});
 

--- a/packages/core/src/rd-parser.ts
+++ b/packages/core/src/rd-parser.ts
@@ -11,13 +11,22 @@
  *   PrimaryExpression = '(' OrExpression ')' | '-' FieldName | FieldExpression
  *   FieldExpression   = FieldName ('?' | EXISTS | ComparisonOp Value | OneOfOp '[' Values ']')?
  *   FieldName         = IDENT ('.' IDENT)*
- *   Value             = STRING | NUMBER | BOOLEAN | DottedIdent | Range
- *   Values            = Value (',' Value)*        (ranges are rejected)
+ *   Value             = STRING | NUMBER | BOOLEAN | DottedIdent | Range | Temporal
+ *   Values            = Value (',' Value)*        (ranges and temporals are rejected)
  *   Range             = NUMBER '..' NUMBER        (only with =, : or !=)
+ *   Temporal          = '@' Point ('..' Point)?   (ranges only with =, : or !=)
+ *   Point             = Date | 'now' (('+' | '-') NUMBER Unit)?
  */
 
 import { FiltronParseError } from "./errors";
-import { Lexer, type Token, type TokenType, type StringToken, type NumberToken } from "./lexer";
+import {
+	Lexer,
+	type Token,
+	type TokenType,
+	type StringToken,
+	type NumberToken,
+	type TemporalToken,
+} from "./lexer";
 import type { ParseOptions } from "./parser";
 import type { ASTNode, Value, ComparisonOperator, OneOfExpression } from "./types";
 
@@ -259,6 +268,12 @@ class Parser {
 					opToken.start,
 				);
 			}
+			if ((value.type === "date" || value.type === "now") && operator === "~") {
+				throw new FiltronParseError(
+					"Temporal values cannot be used with the ~ operator",
+					opToken.start,
+				);
+			}
 
 			return {
 				type: "comparison",
@@ -367,6 +382,9 @@ class Parser {
 		if (value.type === "range") {
 			throw new FiltronParseError("Range values are not allowed in arrays", start);
 		}
+		if (value.type === "date" || value.type === "now") {
+			throw new FiltronParseError("Temporal values are not allowed in arrays", start);
+		}
 		return value;
 	}
 
@@ -391,7 +409,7 @@ class Parser {
 						token.start,
 					);
 				}
-				return { type: "range", min: token.value, max: maxToken.value };
+				return { type: "range", kind: "number", min: token.value, max: maxToken.value };
 			}
 			return { type: "number", value: token.value };
 		}
@@ -404,6 +422,12 @@ class Parser {
 		if (t === "FALSE") {
 			this.advance();
 			return { type: "boolean", value: false };
+		}
+
+		// Temporal literal: the lexer builds the finished value
+		if (t === "TEMPORAL") {
+			const token = this.advance() as TemporalToken;
+			return token.value;
 		}
 
 		// Identifier (possibly dotted)

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -17,7 +17,14 @@ export type ASTNode =
 /**
  * Value type - represents literal values in expressions
  */
-export type Value = StringValue | NumberValue | BooleanValue | IdentifierValue | RangeValue;
+export type Value =
+	| StringValue
+	| NumberValue
+	| BooleanValue
+	| IdentifierValue
+	| RangeValue
+	| DateValue
+	| NowValue;
 
 /**
  * Comparison operators supported
@@ -130,12 +137,61 @@ export interface IdentifierValue {
 }
 
 /**
- * Range value - an inclusive numeric interval
+ * Units for now-relative offsets
+ * Case-sensitive: m is minutes, M is months
+ */
+export type DurationUnit = "s" | "m" | "h" | "d" | "w" | "M" | "y";
+
+/**
+ * Date value - an absolute point in time, written as @<ISO 8601>
+ * Example: @2024-06-01, @2024-06-30T14:00:00Z
+ */
+export interface DateValue {
+	type: "date";
+	value: string;
+}
+
+/**
+ * Now value - a point in time relative to evaluation, written as
+ * @now with an optional offset. Inert at parse time: adapters reject
+ * it until it is resolved to a DateValue
+ * Example: @now, @now-7d, @now+2h
+ */
+export interface NowValue {
+	type: "now";
+	offset: { amount: number; unit: DurationUnit } | null;
+}
+
+/**
+ * A temporal range bound: an absolute date or a now-relative point
+ */
+export type TemporalPoint = DateValue | NowValue;
+
+/**
+ * Range value over numbers - an inclusive interval
  * Valid with the =, : and != operators only
  * Example: age = 18..65, price != 0..100
  */
-export interface RangeValue {
+export interface NumberRangeValue {
 	type: "range";
+	kind: "number";
 	min: number;
 	max: number;
 }
+
+/**
+ * Range value over points in time - an inclusive interval
+ * Valid with the =, : and != operators only
+ * Example: deployed = @2024-06-01..2024-06-30, created = @now-7d..now
+ */
+export interface TemporalRangeValue {
+	type: "range";
+	kind: "temporal";
+	min: TemporalPoint;
+	max: TemporalPoint;
+}
+
+/**
+ * Range value - an inclusive interval over numbers or points in time
+ */
+export type RangeValue = NumberRangeValue | TemporalRangeValue;

--- a/packages/js/src/filter.test.ts
+++ b/packages/js/src/filter.test.ts
@@ -194,7 +194,7 @@ describe("toFilter", () => {
 				type: "comparison",
 				field: "age",
 				operator: "=",
-				value: { type: "range", min: 18, max: 65 },
+				value: { type: "range", kind: "number", min: 18, max: 65 },
 			};
 			const filter = toFilter(ast);
 			expect(filter({ age: 18 })).toBe(true);
@@ -211,7 +211,7 @@ describe("toFilter", () => {
 				type: "comparison",
 				field: "age",
 				operator: "!=",
-				value: { type: "range", min: 18, max: 65 },
+				value: { type: "range", kind: "number", min: 18, max: 65 },
 			};
 			const filter = toFilter(ast);
 			expect(filter({ age: 17 })).toBe(true);
@@ -226,7 +226,7 @@ describe("toFilter", () => {
 				type: "comparison",
 				field: "age",
 				operator: "!=",
-				value: { type: "range", min: 18, max: 65 },
+				value: { type: "range", kind: "number", min: 18, max: 65 },
 			};
 			const filter = toFilter(ast, { fieldAccessor: (obj, field) => obj[field] });
 			expect(filter({ age: 17 })).toBe(true);
@@ -238,7 +238,7 @@ describe("toFilter", () => {
 				type: "comparison",
 				field: "age",
 				operator: ":",
-				value: { type: "range", min: 18, max: 65 },
+				value: { type: "range", kind: "number", min: 18, max: 65 },
 			};
 			const filter = toFilter(ast);
 			expect(filter({ age: 30 })).toBe(true);
@@ -250,7 +250,7 @@ describe("toFilter", () => {
 				type: "comparison",
 				field: "age",
 				operator: ">",
-				value: { type: "range", min: 18, max: 65 },
+				value: { type: "range", kind: "number", min: 18, max: 65 },
 			};
 			expect(() => toFilter(ast)).toThrow("Range values require the =, : or != operator");
 		});
@@ -260,9 +260,179 @@ describe("toFilter", () => {
 				type: "oneOf",
 				field: "age",
 				negated: false,
-				values: [{ type: "range", min: 1, max: 2 }],
+				values: [{ type: "range", kind: "number", min: 1, max: 2 }],
 			};
 			expect(() => toFilter(ast)).toThrow("Range values cannot be used here");
+		});
+	});
+
+	describe("Temporal Values", () => {
+		const june = Date.parse("2024-06-01");
+
+		test("date comparisons accept Date, ISO string and epoch fields", () => {
+			const ast: ComparisonExpression = {
+				type: "comparison",
+				field: "created",
+				operator: ">",
+				value: { type: "date", value: "2024-06-01" },
+			};
+			const filter = toFilter(ast);
+			expect(filter({ created: new Date("2024-07-01") })).toBe(true);
+			expect(filter({ created: "2024-07-01" })).toBe(true);
+			expect(filter({ created: Date.parse("2024-07-01") })).toBe(true);
+			expect(filter({ created: "2024-05-01" })).toBe(false);
+			expect(filter({ created: "not a date" })).toBe(false);
+			expect(filter({ created: true })).toBe(false);
+			expect(filter({})).toBe(false);
+		});
+
+		test.each([
+			["=", june, true],
+			["=", Date.parse("2024-07-01"), false],
+			["!=", june, false],
+			["!=", Date.parse("2024-07-01"), true],
+			[">=", june, true],
+			["<", june, false],
+			["<=", june, true],
+		] as const)("date %s comparison", (operator, created, expected) => {
+			const ast: ComparisonExpression = {
+				type: "comparison",
+				field: "created",
+				operator,
+				value: { type: "date", value: "2024-06-01" },
+			};
+			expect(toFilter(ast)({ created })).toBe(expected);
+		});
+
+		test("!= treats non-dates as not equal", () => {
+			const ast: ComparisonExpression = {
+				type: "comparison",
+				field: "created",
+				operator: "!=",
+				value: { type: "date", value: "2024-06-01" },
+			};
+			expect(toFilter(ast)({ created: "not a date" })).toBe(true);
+		});
+
+		test("date comparison with custom accessor", () => {
+			const ast: ComparisonExpression = {
+				type: "comparison",
+				field: "created",
+				operator: ">",
+				value: { type: "date", value: "2024-06-01" },
+			};
+			const filter = toFilter(ast, { fieldAccessor: (obj, field) => obj[field] });
+			expect(filter({ created: "2024-07-01" })).toBe(true);
+			expect(filter({ created: "2024-05-01" })).toBe(false);
+		});
+
+		test("temporal range matches the inclusive interval", () => {
+			const ast: ComparisonExpression = {
+				type: "comparison",
+				field: "created",
+				operator: "=",
+				value: {
+					type: "range",
+					kind: "temporal",
+					min: { type: "date", value: "2024-06-01" },
+					max: { type: "date", value: "2024-06-30" },
+				},
+			};
+			const filter = toFilter(ast);
+			expect(filter({ created: "2024-06-15" })).toBe(true);
+			expect(filter({ created: "2024-06-01" })).toBe(true);
+			expect(filter({ created: "2024-07-01" })).toBe(false);
+			expect(filter({ created: "not a date" })).toBe(false);
+		});
+
+		test("negated temporal range matches outside, including non-dates", () => {
+			const ast: ComparisonExpression = {
+				type: "comparison",
+				field: "created",
+				operator: "!=",
+				value: {
+					type: "range",
+					kind: "temporal",
+					min: { type: "date", value: "2024-06-01" },
+					max: { type: "date", value: "2024-06-30" },
+				},
+			};
+			const filter = toFilter(ast);
+			expect(filter({ created: "2024-07-01" })).toBe(true);
+			expect(filter({ created: "2024-06-15" })).toBe(false);
+			expect(filter({ created: "not a date" })).toBe(true);
+		});
+
+		test("temporal range with custom accessor and ordering operator guard", () => {
+			const range: ComparisonExpression = {
+				type: "comparison",
+				field: "created",
+				operator: ":",
+				value: {
+					type: "range",
+					kind: "temporal",
+					min: { type: "date", value: "2024-06-01" },
+					max: { type: "date", value: "2024-06-30" },
+				},
+			};
+			const filter = toFilter(range, { fieldAccessor: (obj, field) => obj[field] });
+			expect(filter({ created: "2024-06-15" })).toBe(true);
+
+			const bad: ComparisonExpression = {
+				type: "comparison",
+				field: "created",
+				operator: ">",
+				value: {
+					type: "range",
+					kind: "temporal",
+					min: { type: "date", value: "2024-06-01" },
+					max: { type: "date", value: "2024-06-30" },
+				},
+			};
+			expect(() => toFilter(bad)).toThrow("Range values require the =, : or != operator");
+		});
+
+		test("unresolved now values throw", () => {
+			const point: ComparisonExpression = {
+				type: "comparison",
+				field: "created",
+				operator: ">",
+				value: { type: "now", offset: { amount: -7, unit: "d" } },
+			};
+			expect(() => toFilter(point)).toThrow("Unresolved relative time value");
+
+			const range: ComparisonExpression = {
+				type: "comparison",
+				field: "created",
+				operator: "=",
+				value: {
+					type: "range",
+					kind: "temporal",
+					min: { type: "now", offset: { amount: -7, unit: "d" } },
+					max: { type: "now", offset: null },
+				},
+			};
+			expect(() => toFilter(range)).toThrow("Unresolved relative time value");
+		});
+
+		test("temporal values in membership arrays throw", () => {
+			const ast: OneOfExpression = {
+				type: "oneOf",
+				field: "created",
+				negated: false,
+				values: [{ type: "date", value: "2024-06-01" }],
+			};
+			expect(() => toFilter(ast)).toThrow("Temporal values cannot be used here");
+		});
+
+		test("hand-built temporal value with contains operator throws", () => {
+			const ast: ComparisonExpression = {
+				type: "comparison",
+				field: "created",
+				operator: "~",
+				value: { type: "date", value: "2024-06-01" },
+			};
+			expect(() => toFilter(ast)).toThrow("Temporal values cannot be used with the ~ operator");
 		});
 	});
 
@@ -333,6 +503,20 @@ describe("toFilter", () => {
 			expect(filter({ email: null })).toBe(false);
 			expect(filter({ email: undefined })).toBe(false);
 			expect(filter({ name: "test" })).toBe(false);
+		});
+	});
+
+	describe("Negated Exists", () => {
+		test("matches null and missing, with and without accessor", () => {
+			const ast: ExistsExpression = { type: "exists", field: "email", negated: true };
+			const plain = toFilter(ast);
+			expect(plain({ email: null })).toBe(true);
+			expect(plain({})).toBe(true);
+			expect(plain({ email: "a@b.c" })).toBe(false);
+
+			const accessor = toFilter(ast, { fieldAccessor: (obj, field) => obj[field] });
+			expect(accessor({ email: null })).toBe(true);
+			expect(accessor({ email: "a@b.c" })).toBe(false);
 		});
 	});
 
@@ -454,7 +638,7 @@ describe("toFilter", () => {
 						type: "comparison",
 						field: "x",
 						operator: "=",
-						value: { type: "range", min: 0, max: 1 },
+						value: { type: "range", kind: "number", min: 0, max: 1 },
 					},
 					{ allowedFields: [] },
 				),
@@ -638,7 +822,7 @@ describe("toFilter", () => {
 				type: "comparison",
 				field: "user_age",
 				operator: "=",
-				value: { type: "range", min: 18, max: 65 },
+				value: { type: "range", kind: "number", min: 18, max: 65 },
 			};
 			const filter = toFilter(ast, {
 				fieldMapping: {
@@ -778,7 +962,7 @@ describe("toFilter", () => {
 				type: "comparison",
 				field: "age",
 				operator: "=",
-				value: { type: "range", min: 18, max: 65 },
+				value: { type: "range", kind: "number", min: 18, max: 65 },
 			};
 			const opts = { fieldAccessor: accessor };
 			expect(toFilter(exists, opts)({ email: "a@b.c" })).toBe(true);

--- a/packages/js/src/filter.ts
+++ b/packages/js/src/filter.ts
@@ -11,9 +11,11 @@ import type {
 	AndExpression,
 	NotExpression,
 	ComparisonExpression,
+	ComparisonOperator,
 	OneOfExpression,
 	ExistsExpression,
 	BooleanFieldExpression,
+	TemporalPoint,
 } from "@filtron/core";
 
 /**
@@ -257,6 +259,17 @@ function generateComparison(node: ComparisonExpression, state: GeneratorState): 
 	const field = resolveField(node.field, state);
 
 	if (node.value.type === "range") {
+		if (node.value.kind === "temporal") {
+			const min = temporalBoundEpoch(node.value.min);
+			const max = temporalBoundEpoch(node.value.max);
+			if (node.operator === "=" || node.operator === ":") {
+				return generateDateRange(field, false, min, max, state);
+			}
+			if (node.operator === "!=") {
+				return generateDateRange(field, true, min, max, state);
+			}
+			throw new Error(`Range values require the =, : or != operator, got ${node.operator}`);
+		}
 		const { min, max } = node.value;
 		if (node.operator === "=" || node.operator === ":") {
 			return generateRangeComparison(field, "=", min, max, state);
@@ -265,6 +278,14 @@ function generateComparison(node: ComparisonExpression, state: GeneratorState): 
 			return generateRangeComparison(field, "!=", min, max, state);
 		}
 		throw new Error(`Range values require the =, : or != operator, got ${node.operator}`);
+	}
+
+	if (node.value.type === "date") {
+		return generateDateComparison(field, node.operator, Date.parse(node.value.value), state);
+	}
+
+	if (node.value.type === "now") {
+		throw new Error(UNRESOLVED_NOW);
 	}
 
 	const targetValue = extractValue(node.value);
@@ -613,6 +634,101 @@ function generateRangeComparison(
 	};
 }
 
+const UNRESOLVED_NOW =
+	"Unresolved relative time value: resolve now-relative values before filtering";
+
+/**
+ * Converts a temporal range bound to an epoch; now-relative bounds
+ * must be resolved before filtering
+ */
+function temporalBoundEpoch(point: TemporalPoint): number {
+	if (point.type === "now") {
+		throw new Error(UNRESOLVED_NOW);
+	}
+	return Date.parse(point.value);
+}
+
+/**
+ * Coerces a field value to an epoch for date comparisons: Date
+ * instances, ISO strings and epoch numbers are accepted; everything
+ * else yields NaN and never matches (except through !=)
+ */
+function toEpoch(value: unknown): number {
+	if (typeof value === "number") {
+		return value;
+	}
+	if (typeof value === "string") {
+		return Date.parse(value);
+	}
+	if (value instanceof Date) {
+		return value.getTime();
+	}
+	return NaN;
+}
+
+/**
+ * Generates predicate for a comparison against a date value,
+ * compared as epoch milliseconds
+ */
+function generateDateComparison(
+	field: string,
+	operator: ComparisonOperator,
+	target: number,
+	state: GeneratorState,
+): FilterPredicate<Record<string, unknown>> {
+	const accessor = state.fieldAccessor;
+	const get = accessor
+		? (item: Record<string, unknown>) => toEpoch(accessor(item, field))
+		: (item: Record<string, unknown>) => toEpoch(item[field]);
+
+	switch (operator) {
+		case "=":
+		case ":":
+			return (item) => get(item) === target;
+		case "!=":
+			return (item) => get(item) !== target;
+		case ">":
+			return (item) => get(item) > target;
+		case ">=":
+			return (item) => get(item) >= target;
+		case "<":
+			return (item) => get(item) < target;
+		case "<=":
+			return (item) => get(item) <= target;
+		default:
+			// The parser rejects ~ against temporal values
+			throw new Error(`Temporal values cannot be used with the ${operator} operator`);
+	}
+}
+
+/**
+ * Generates predicate for a temporal range, compared as epoch
+ * milliseconds; NaN field values fall outside every interval
+ */
+function generateDateRange(
+	field: string,
+	negated: boolean,
+	min: number,
+	max: number,
+	state: GeneratorState,
+): FilterPredicate<Record<string, unknown>> {
+	const accessor = state.fieldAccessor;
+	const get = accessor
+		? (item: Record<string, unknown>) => toEpoch(accessor(item, field))
+		: (item: Record<string, unknown>) => toEpoch(item[field]);
+
+	if (negated) {
+		return (item) => {
+			const epoch = get(item);
+			return !(epoch >= min && epoch <= max);
+		};
+	}
+	return (item) => {
+		const epoch = get(item);
+		return epoch >= min && epoch <= max;
+	};
+}
+
 /**
  * Extracts the primitive value from a Filtron Value node
  */
@@ -621,6 +737,10 @@ function extractValue(value: Value): string | number | boolean {
 		case "range":
 			// The parser only produces ranges where callers handle them first
 			throw new Error("Range values cannot be used here");
+		case "date":
+		case "now":
+			// The parser rejects temporal values in arrays
+			throw new Error("Temporal values cannot be used here");
 		case "string":
 			return value.value;
 		case "number":

--- a/packages/js/src/filter.ts
+++ b/packages/js/src/filter.ts
@@ -675,7 +675,7 @@ function generateDateComparison(
 	operator: ComparisonOperator,
 	target: number,
 	state: GeneratorState,
-): FilterPredicate<Record<string, unknown>> {
+): FilterPredicate {
 	const accessor = state.fieldAccessor;
 	const get = accessor
 		? (item: Record<string, unknown>) => toEpoch(accessor(item, field))
@@ -711,7 +711,7 @@ function generateDateRange(
 	min: number,
 	max: number,
 	state: GeneratorState,
-): FilterPredicate<Record<string, unknown>> {
+): FilterPredicate {
 	const accessor = state.fieldAccessor;
 	const get = accessor
 		? (item: Record<string, unknown>) => toEpoch(accessor(item, field))

--- a/packages/sql/src/converter.test.ts
+++ b/packages/sql/src/converter.test.ts
@@ -423,6 +423,16 @@ describe("SQL", () => {
 			expect(result.params).toEqual(["2024-06-01", "2024-06-30"]);
 		});
 
+		test("contains operator against a date throws", () => {
+			const ast: ASTNode = {
+				type: "comparison",
+				field: "created",
+				operator: "~",
+				value: { type: "date", value: "2024-06-01" },
+			};
+			expect(() => toSQL(ast)).toThrow("Temporal values cannot be used with the ~ operator");
+		});
+
 		test("unresolved now values throw", () => {
 			const point: ASTNode = {
 				type: "comparison",

--- a/packages/sql/src/converter.test.ts
+++ b/packages/sql/src/converter.test.ts
@@ -262,7 +262,7 @@ describe("SQL", () => {
 				type: "comparison",
 				field: "age",
 				operator: "=",
-				value: { type: "range", min: 18, max: 65 },
+				value: { type: "range", kind: "number", min: 18, max: 65 },
 			};
 
 			const result = toSQL(ast);
@@ -275,7 +275,7 @@ describe("SQL", () => {
 				type: "comparison",
 				field: "price",
 				operator: "=",
-				value: { type: "range", min: 9.99, max: 99.99 },
+				value: { type: "range", kind: "number", min: 9.99, max: 99.99 },
 			};
 
 			const result = toSQL(ast);
@@ -288,7 +288,7 @@ describe("SQL", () => {
 				type: "comparison",
 				field: "temperature",
 				operator: "=",
-				value: { type: "range", min: -20, max: 40 },
+				value: { type: "range", kind: "number", min: -20, max: 40 },
 			};
 
 			const result = toSQL(ast);
@@ -301,7 +301,7 @@ describe("SQL", () => {
 				type: "comparison",
 				field: "age",
 				operator: "!=",
-				value: { type: "range", min: 18, max: 65 },
+				value: { type: "range", kind: "number", min: 18, max: 65 },
 			};
 
 			const result = toSQL(ast);
@@ -314,7 +314,7 @@ describe("SQL", () => {
 				type: "comparison",
 				field: "age",
 				operator: ":",
-				value: { type: "range", min: 18, max: 65 },
+				value: { type: "range", kind: "number", min: 18, max: 65 },
 			};
 
 			const result = toSQL(ast);
@@ -326,7 +326,7 @@ describe("SQL", () => {
 				type: "comparison",
 				field: "age",
 				operator: ">",
-				value: { type: "range", min: 18, max: 65 },
+				value: { type: "range", kind: "number", min: 18, max: 65 },
 			};
 
 			expect(() => toSQL(ast)).toThrow("Range values require the =, : or != operator");
@@ -337,7 +337,7 @@ describe("SQL", () => {
 				type: "oneOf",
 				field: "age",
 				negated: false,
-				values: [{ type: "range", min: 1, max: 2 }],
+				values: [{ type: "range", kind: "number", min: 1, max: 2 }],
 			};
 
 			expect(() => toSQL(ast)).toThrow("Range values cannot be used here");
@@ -348,7 +348,7 @@ describe("SQL", () => {
 				type: "comparison",
 				field: "user.age",
 				operator: "=",
-				value: { type: "range", min: 18, max: 65 },
+				value: { type: "range", kind: "number", min: 18, max: 65 },
 			};
 
 			const result = toSQL(ast, {
@@ -357,6 +357,103 @@ describe("SQL", () => {
 
 			expect(result.sql).toBe("t.user.age BETWEEN $1 AND $2");
 			expect(result.params).toEqual([18, 65]);
+		});
+	});
+
+	describe("Temporal Values", () => {
+		test("date comparison parameterizes the ISO string", () => {
+			const ast: ASTNode = {
+				type: "comparison",
+				field: "created",
+				operator: ">",
+				value: { type: "date", value: "2024-06-01" },
+			};
+
+			const result = toSQL(ast);
+			expect(result.sql).toBe("created > $1");
+			expect(result.params).toEqual(["2024-06-01"]);
+		});
+
+		test("date equality and datetime values", () => {
+			const ast: ASTNode = {
+				type: "comparison",
+				field: "created",
+				operator: "=",
+				value: { type: "date", value: "2024-06-01T14:30:00Z" },
+			};
+
+			const result = toSQL(ast);
+			expect(result.sql).toBe("created = $1");
+			expect(result.params).toEqual(["2024-06-01T14:30:00Z"]);
+		});
+
+		test("temporal range uses BETWEEN with ISO parameters", () => {
+			const ast: ASTNode = {
+				type: "comparison",
+				field: "created",
+				operator: "=",
+				value: {
+					type: "range",
+					kind: "temporal",
+					min: { type: "date", value: "2024-06-01" },
+					max: { type: "date", value: "2024-06-30" },
+				},
+			};
+
+			const result = toSQL(ast);
+			expect(result.sql).toBe("created BETWEEN $1 AND $2");
+			expect(result.params).toEqual(["2024-06-01", "2024-06-30"]);
+		});
+
+		test("negated temporal range uses NOT BETWEEN", () => {
+			const ast: ASTNode = {
+				type: "comparison",
+				field: "created",
+				operator: "!=",
+				value: {
+					type: "range",
+					kind: "temporal",
+					min: { type: "date", value: "2024-06-01" },
+					max: { type: "date", value: "2024-06-30" },
+				},
+			};
+
+			const result = toSQL(ast);
+			expect(result.sql).toBe("created NOT BETWEEN $1 AND $2");
+			expect(result.params).toEqual(["2024-06-01", "2024-06-30"]);
+		});
+
+		test("unresolved now values throw", () => {
+			const point: ASTNode = {
+				type: "comparison",
+				field: "created",
+				operator: ">",
+				value: { type: "now", offset: { amount: -7, unit: "d" } },
+			};
+			expect(() => toSQL(point)).toThrow("Unresolved relative time value");
+
+			const range: ASTNode = {
+				type: "comparison",
+				field: "created",
+				operator: "=",
+				value: {
+					type: "range",
+					kind: "temporal",
+					min: { type: "now", offset: null },
+					max: { type: "date", value: "2024-06-30" },
+				},
+			};
+			expect(() => toSQL(range)).toThrow("Unresolved relative time value");
+		});
+
+		test("temporal values in membership arrays throw", () => {
+			const ast: ASTNode = {
+				type: "oneOf",
+				field: "created",
+				negated: false,
+				values: [{ type: "now", offset: null }],
+			};
+			expect(() => toSQL(ast)).toThrow("Temporal values cannot be used here");
 		});
 	});
 

--- a/packages/sql/src/converter.ts
+++ b/packages/sql/src/converter.ts
@@ -247,6 +247,10 @@ function generateComparison(node: ComparisonExpression, state: GeneratorState): 
 	}
 
 	if (node.value.type === "date") {
+		if (node.operator === "~") {
+			// The parser rejects this; guards hand-built ASTs like @filtron/js
+			throw new Error("Temporal values cannot be used with the ~ operator");
+		}
 		const param = addParameter(node.value.value, state);
 		return `${field} ${mapComparisonOperator(node.operator)} ${param}`;
 	}

--- a/packages/sql/src/converter.ts
+++ b/packages/sql/src/converter.ts
@@ -8,6 +8,7 @@ import type {
 	ASTNode,
 	Value,
 	ComparisonOperator,
+	TemporalPoint,
 	OrExpression,
 	AndExpression,
 	NotExpression,
@@ -228,8 +229,14 @@ function generateComparison(node: ComparisonExpression, state: GeneratorState): 
 	const field = state.fieldMapper(node.field);
 
 	if (node.value.type === "range") {
-		const minParam = addParameter(node.value.min, state);
-		const maxParam = addParameter(node.value.max, state);
+		const minParam = addParameter(
+			node.value.kind === "temporal" ? temporalBoundParam(node.value.min) : node.value.min,
+			state,
+		);
+		const maxParam = addParameter(
+			node.value.kind === "temporal" ? temporalBoundParam(node.value.max) : node.value.max,
+			state,
+		);
 		if (node.operator === "=" || node.operator === ":") {
 			return `${field} BETWEEN ${minParam} AND ${maxParam}`;
 		}
@@ -237,6 +244,15 @@ function generateComparison(node: ComparisonExpression, state: GeneratorState): 
 			return `${field} NOT BETWEEN ${minParam} AND ${maxParam}`;
 		}
 		throw new Error(`Range values require the =, : or != operator, got ${node.operator}`);
+	}
+
+	if (node.value.type === "date") {
+		const param = addParameter(node.value.value, state);
+		return `${field} ${mapComparisonOperator(node.operator)} ${param}`;
+	}
+
+	if (node.value.type === "now") {
+		throw new Error(UNRESOLVED_NOW);
 	}
 
 	const operator = mapComparisonOperator(node.operator);
@@ -321,6 +337,20 @@ function mapComparisonOperator(operator: ComparisonOperator): string {
 	}
 }
 
+const UNRESOLVED_NOW =
+	"Unresolved relative time value: resolve now-relative values before generating SQL";
+
+/**
+ * Converts a temporal range bound to its parameter value; now-relative
+ * bounds must be resolved before generating SQL
+ */
+function temporalBoundParam(point: TemporalPoint): string {
+	if (point.type === "now") {
+		throw new Error(UNRESOLVED_NOW);
+	}
+	return point.value;
+}
+
 /**
  * Extracts the primitive value from a Filtron Value node
  */
@@ -329,6 +359,10 @@ function extractValue(value: Value): string | number | boolean {
 		case "range":
 			// The parser only produces ranges where callers handle them first
 			throw new Error("Range values cannot be used here");
+		case "date":
+		case "now":
+			// The parser rejects temporal values in arrays
+			throw new Error("Temporal values cannot be used here");
 		case "string":
 			return value.value;
 		case "number":

--- a/website/src/highlight.ts
+++ b/website/src/highlight.ts
@@ -37,6 +37,7 @@ function tokenTypeToClass(type: TokenType): HighlightClass | null {
 		case "STRING":
 			return "string";
 		case "NUMBER":
+		case "TEMPORAL":
 			return "number";
 		case "LPAREN":
 		case "RPAREN":


### PR DESCRIPTION
### Why

Introduce date filtering: `@` opens a temporal literal, keeping the feature purely additive (`@` was a lex error in 2.x), `readNumber` is untouched, and no identifier (including `now`) changes meaning.

### What

```
created  > @2024-06-01           absolute points, all operators except ~
updated  > @now-1h               now-relative points, inert until resolved
deployed = @2024-06-01..2024-06-30   ranges: single sigil, bounds stay temporal
created  = @now-7d..now
```

- Two new Value members: `DateValue` (ISO 8601, calendar-validated in the scanner — JSC's `Date.parse` rolls invalid days over, so validation is explicit math) and `NowValue` (signed offset in `s/m/h/d/w/M/y`). Union members land now so the resolver package can arrive later without breaking exhaustive switches.
- `RangeValue` becomes a discriminated pair: `kind: "number"` keeps the existing shape (BREAKING for hand-built literals, which need the `kind` field), `kind: "temporal"` carries date or now bounds. Ordering is validated only where timezone-independent (date-only bounds, lexicographic).
- The `@` scanner consumes the entire literal in one place: one new character-class entry, one token, no parser stitching, `now - 7d` with spaces is simply not valid syntax.
- @filtron/js compares dates as epoch milliseconds and accepts `Date`, ISO string, or epoch number field values; non-dates never match except through `!=`. @filtron/sql passes ISO strings as parameters and maps temporal ranges to BETWEEN / NOT BETWEEN. Both adapters throw "Unresolved relative time value" on `now` values, and reject temporal values in membership arrays (also a parse error).
- Conformance gains a `created` column and two temporal cases; grammar docs, core README, tmLanguage, the query-syntax example, and the website highlighter all updated.

### Notes

- Naive datetimes (`@2024-06-01T14:00:00`, no zone) are interpreted in the runtime's local timezone by @filtron/js at compile time — same caveat as SQL timestamp columns; documented rather than rejected.
- Core grows ~1 KB minified (~9%), per the size analysis on the issue.

Closes: #265 