### PR TITLE
chore: stricter lint defaults

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,7 +48,8 @@ jobs:
         with:
           bun-version-file: package.json
       - run: bun ci
-      - run: bun oxlint --type-aware
+      - run: bun run build
+      - run: bun oxlint --type-aware --type-check
 
   format:
     runs-on: ubuntu-slim

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -33,9 +33,20 @@
 		"typescript/no-unnecessary-type-assertion": "error",
 		"typescript/no-unnecessary-type-arguments": "error",
 		"no-shadow": "error",
-		"typescript/consistent-return": "error"
+		"typescript/consistent-return": "error",
+		"typescript/no-unsafe-type-assertion": "off",
+		"no-underscore-dangle": "off"
 	},
 	"categories": {
-		"correctness": "error"
-	}
+		"correctness": "error",
+		"suspicious": "error"
+	},
+	"overrides": [
+		{
+			"files": ["**/*.test.ts"],
+			"rules": {
+				"unicorn/consistent-function-scoping": "off"
+			}
+		}
+	]
 }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -17,6 +17,25 @@
 		"bad-bitwise-operator": "error",
 		"no-barrel-file": "error",
 		"no-const-enum": "error",
-		"no-rest-spread-properties": "error"
+		"no-rest-spread-properties": "error",
+		"no-unused-vars": [
+			"error",
+			{
+				"varsIgnorePattern": "^_",
+				"argsIgnorePattern": "^_",
+				"ignoreRestSiblings": true
+			}
+		],
+		"typescript/no-explicit-any": "error",
+		"typescript/consistent-type-imports": "error",
+		"import/no-duplicates": "error",
+		"eqeqeq": "error",
+		"typescript/no-unnecessary-type-assertion": "error",
+		"typescript/no-unnecessary-type-arguments": "error",
+		"no-shadow": "error",
+		"typescript/consistent-return": "error"
+	},
+	"categories": {
+		"correctness": "error"
 	}
 }

--- a/bun.lock
+++ b/bun.lock
@@ -125,6 +125,7 @@
       },
       "devDependencies": {
         "@iconscout/unicons": "4.2.0",
+        "@types/bun": "catalog:",
         "shiki": "4.3.1",
         "wrangler": "4.110.0",
       },

--- a/examples/elysia-sqlite/src/db.ts
+++ b/examples/elysia-sqlite/src/db.ts
@@ -3,7 +3,7 @@
  * Uses Bun's built-in SQLite driver
  */
 
-import { Database } from "bun:sqlite";
+import { Database, type SQLQueryBindings } from "bun:sqlite";
 import { faker } from "@faker-js/faker";
 import type { SQLResult } from "@filtron/sql";
 
@@ -39,8 +39,8 @@ export function getAllUsers(): User[] {
  */
 export function getFilteredUsers(sqlResult: SQLResult): User[] {
 	const sql = `SELECT * FROM users WHERE ${sqlResult.sql} ORDER BY id`;
-	const query = db.query<User, any[]>(sql);
-	return query.all(...sqlResult.params);
+	const query = db.query<User, SQLQueryBindings[]>(sql);
+	return query.all(...(sqlResult.params as SQLQueryBindings[]));
 }
 
 /**
@@ -86,8 +86,8 @@ function generateUsers(count: number) {
 /**
  * Initialize database and seed with data
  */
-export function seedDatabase(db: Database, count: number = 500): void {
-	db.exec(`
+export function seedDatabase(database: Database, count: number = 500): void {
+	database.exec(`
     CREATE TABLE IF NOT EXISTS users (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       name TEXT NOT NULL,
@@ -100,20 +100,20 @@ export function seedDatabase(db: Database, count: number = 500): void {
     )
   `);
 
-	db.exec("CREATE INDEX IF NOT EXISTS idx_users_status ON users(status)");
-	db.exec("CREATE INDEX IF NOT EXISTS idx_users_role ON users(role)");
-	db.exec("CREATE INDEX IF NOT EXISTS idx_users_age ON users(age)");
-	db.exec("CREATE INDEX IF NOT EXISTS idx_users_verified ON users(verified)");
+	database.exec("CREATE INDEX IF NOT EXISTS idx_users_status ON users(status)");
+	database.exec("CREATE INDEX IF NOT EXISTS idx_users_role ON users(role)");
+	database.exec("CREATE INDEX IF NOT EXISTS idx_users_age ON users(age)");
+	database.exec("CREATE INDEX IF NOT EXISTS idx_users_verified ON users(verified)");
 
 	// Check if already seeded
-	const result = db.query<{ count: number }, []>("SELECT COUNT(*) as count FROM users").get();
+	const result = database.query<{ count: number }, []>("SELECT COUNT(*) as count FROM users").get();
 	if (result && result.count > 0) {
 		return;
 	}
 
 	// Generate and insert users
 	const users = generateUsers(count);
-	const insertStmt = db.prepare(
+	const insertStmt = database.prepare(
 		"INSERT INTO users (name, email, age, status, role, verified) VALUES (?, ?, ?, ?, ?, ?)",
 	);
 
@@ -124,8 +124,8 @@ export function seedDatabase(db: Database, count: number = 500): void {
 
 // Run seed if called directly (useful for testing seed logic)
 if (import.meta.main) {
-	const db = new Database(":memory:");
-	seedDatabase(db);
+	const memoryDb = new Database(":memory:");
+	seedDatabase(memoryDb);
 	console.log("✓ In-memory database seeded successfully");
-	db.close();
+	memoryDb.close();
 }

--- a/examples/elysia-sqlite/src/index-e2e.test.ts
+++ b/examples/elysia-sqlite/src/index-e2e.test.ts
@@ -6,6 +6,16 @@ import { describe, test, expect, beforeAll, afterAll } from "bun:test";
 import { db, seedDatabase } from "./db";
 import { app } from "./index";
 
+interface ApiUser {
+	name: string;
+	age: number;
+	status: string;
+	role: string;
+	verified: boolean;
+	premium: boolean;
+	email: string | null;
+}
+
 describe("Elysia E2E Tests", () => {
 	let server: ReturnType<typeof app.listen>;
 
@@ -44,7 +54,7 @@ describe("Elysia E2E Tests", () => {
 		expect(response.status).toBe(200);
 		expect(data.success).toBe(true);
 		expect(data.count).toBe(353);
-		expect(data.data.every((u: any) => u.status === "active")).toBe(true);
+		expect(data.data.every((u: ApiUser) => u.status === "active")).toBe(true);
 	});
 
 	test("should filter with AND operator", async () => {
@@ -56,7 +66,7 @@ describe("Elysia E2E Tests", () => {
 		expect(response.status).toBe(200);
 		expect(data.success).toBe(true);
 		expect(data.count).toBe(234);
-		expect(data.data.every((u: any) => u.status === "active" && u.verified)).toBe(true);
+		expect(data.data.every((u: ApiUser) => u.status === "active" && u.verified)).toBe(true);
 	});
 
 	test("should filter with one-of operator", async () => {
@@ -68,7 +78,9 @@ describe("Elysia E2E Tests", () => {
 		expect(response.status).toBe(200);
 		expect(data.success).toBe(true);
 		expect(data.count).toBe(318);
-		expect(data.data.every((u: any) => u.role === "admin" || u.role === "moderator")).toBe(true);
+		expect(data.data.every((u: ApiUser) => u.role === "admin" || u.role === "moderator")).toBe(
+			true,
+		);
 	});
 
 	test("should filter with comparison operators", async () => {
@@ -77,12 +89,12 @@ describe("Elysia E2E Tests", () => {
 		);
 		const data1 = await response1.json();
 		expect(data1.count).toBe(375);
-		expect(data1.data.every((u: any) => u.age >= 30)).toBe(true);
+		expect(data1.data.every((u: ApiUser) => u.age >= 30)).toBe(true);
 
 		const response2 = await fetch(`${getBaseUrl()}/users?filter=${encodeURIComponent("age < 30")}`);
 		const data2 = await response2.json();
 		expect(data2.count).toBe(125);
-		expect(data2.data.every((u: any) => u.age < 30)).toBe(true);
+		expect(data2.data.every((u: ApiUser) => u.age < 30)).toBe(true);
 	});
 
 	test("should filter with range expression syntax", async () => {
@@ -94,7 +106,7 @@ describe("Elysia E2E Tests", () => {
 		expect(response.status).toBe(200);
 		expect(data.success).toBe(true);
 		expect(data.count).toBe(113);
-		expect(data.data.every((u: any) => u.age >= 30 && u.age <= 40)).toBe(true);
+		expect(data.data.every((u: ApiUser) => u.age >= 30 && u.age <= 40)).toBe(true);
 		expect(data.filter.sql).toContain("BETWEEN");
 	});
 
@@ -118,7 +130,7 @@ describe("Elysia E2E Tests", () => {
 		expect(response.status).toBe(200);
 		expect(data.success).toBe(true);
 		expect(data.count).toBe(162);
-		expect(data.data.every((u: any) => (u.age < 25 || u.age > 50) && u.verified)).toBe(true);
+		expect(data.data.every((u: ApiUser) => (u.age < 25 || u.age > 50) && u.verified)).toBe(true);
 	});
 
 	test("should handle invalid filter syntax", async () => {

--- a/examples/elysia-sqlite/src/index-e2e.test.ts
+++ b/examples/elysia-sqlite/src/index-e2e.test.ts
@@ -4,17 +4,8 @@
 
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
 import { db, seedDatabase } from "./db";
+import type { User as ApiUser } from "./db";
 import { app } from "./index";
-
-interface ApiUser {
-	name: string;
-	age: number;
-	status: string;
-	role: string;
-	verified: boolean;
-	premium: boolean;
-	email: string | null;
-}
 
 describe("Elysia E2E Tests", () => {
 	let server: ReturnType<typeof app.listen>;

--- a/packages/core/src/rd-parser.ts
+++ b/packages/core/src/rd-parser.ts
@@ -19,15 +19,7 @@
 import { FiltronParseError } from "./errors";
 import { Lexer, type Token, type TokenType, type StringToken, type NumberToken } from "./lexer";
 import type { ParseOptions } from "./parser";
-import type {
-	ASTNode,
-	Value,
-	ComparisonOperator,
-	ComparisonExpression,
-	OneOfExpression,
-	ExistsExpression,
-	BooleanFieldExpression,
-} from "./types";
+import type { ASTNode, Value, ComparisonOperator, OneOfExpression } from "./types";
 
 /**
  * Default maximum query length in characters
@@ -213,7 +205,7 @@ class Parser {
 		if (this.check("MINUS")) {
 			this.advance();
 			const field = this.parseFieldName();
-			return { type: "exists", field, negated: true } as ExistsExpression;
+			return { type: "exists", field, negated: true };
 		}
 
 		// Not a valid primary; parseFieldExpression reports the error
@@ -231,7 +223,7 @@ class Parser {
 		// Exists check with ? or EXISTS
 		if (t === "QUESTION" || t === "EXISTS") {
 			this.advance();
-			return { type: "exists", field, negated: false } as ExistsExpression;
+			return { type: "exists", field, negated: false };
 		}
 
 		// Membership: field : [values]
@@ -273,11 +265,11 @@ class Parser {
 				field,
 				operator,
 				value,
-			} as ComparisonExpression;
+			};
 		}
 
 		// Boolean field shorthand (just the field name)
-		return { type: "booleanField", field } as BooleanFieldExpression;
+		return { type: "booleanField", field };
 	}
 
 	/**

--- a/packages/js/src/filter.test.ts
+++ b/packages/js/src/filter.test.ts
@@ -882,7 +882,7 @@ describe("toFilter", () => {
 			type: "and" | "or",
 			leaves: ComparisonExpression[],
 		): AndExpression | OrExpression => {
-			return { type, children: leaves } as AndExpression;
+			return { type, children: leaves };
 		};
 
 		const leaves = (n: number) => Array.from({ length: n }, (_, i) => comparison(`f${i}`, i));

--- a/packages/js/src/filter.ts
+++ b/packages/js/src/filter.ts
@@ -129,7 +129,7 @@ export function toFilter<T extends Record<string, unknown> = Record<string, unkn
 		fieldMapping: options.fieldMapping,
 	};
 
-	return generateFilter(ast, state) as FilterPredicate<T>;
+	return generateFilter(ast, state);
 }
 
 /**
@@ -142,10 +142,7 @@ function resolveField(field: string, state: GeneratorState): string {
 /**
  * Recursively generates filter predicates from AST nodes
  */
-function generateFilter(
-	node: ASTNode,
-	state: GeneratorState,
-): FilterPredicate<Record<string, unknown>> {
+function generateFilter(node: ASTNode, state: GeneratorState): FilterPredicate {
 	switch (node.type) {
 		case "or":
 			return generateOr(node, state);
@@ -174,10 +171,7 @@ function generateFilter(
  * The parser guarantees flat chains of two or more children; common
  * arities compile to direct short-circuit chains
  */
-function generateOr(
-	node: OrExpression,
-	state: GeneratorState,
-): FilterPredicate<Record<string, unknown>> {
+function generateOr(node: OrExpression, state: GeneratorState): FilterPredicate {
 	const children = node.children;
 	const len = children.length;
 
@@ -214,10 +208,7 @@ function generateOr(
  * The parser guarantees flat chains of two or more children; common
  * arities compile to direct short-circuit chains
  */
-function generateAnd(
-	node: AndExpression,
-	state: GeneratorState,
-): FilterPredicate<Record<string, unknown>> {
+function generateAnd(node: AndExpression, state: GeneratorState): FilterPredicate {
 	const children = node.children;
 	const len = children.length;
 
@@ -252,10 +243,7 @@ function generateAnd(
 /**
  * Generates predicate for NOT expression
  */
-function generateNot(
-	node: NotExpression,
-	state: GeneratorState,
-): FilterPredicate<Record<string, unknown>> {
+function generateNot(node: NotExpression, state: GeneratorState): FilterPredicate {
 	const expr = generateFilter(node.expression, state);
 	return (item) => !expr(item);
 }
@@ -265,10 +253,7 @@ function generateNot(
  * Pre-computes case-insensitive values during compilation and emits
  * direct property access predicates when no custom accessor is set
  */
-function generateComparison(
-	node: ComparisonExpression,
-	state: GeneratorState,
-): FilterPredicate<Record<string, unknown>> {
+function generateComparison(node: ComparisonExpression, state: GeneratorState): FilterPredicate {
 	const field = resolveField(node.field, state);
 
 	if (node.value.type === "range") {
@@ -433,7 +418,7 @@ function generateMembership(
 	state: GeneratorState,
 	emptyResult: boolean,
 	negate: boolean,
-): FilterPredicate<Record<string, unknown>> {
+): FilterPredicate {
 	const values = rawValues.map((v: Value) => extractValue(v));
 	const accessor = state.fieldAccessor;
 
@@ -541,10 +526,7 @@ function generateMembership(
  * Generates predicate for membership expression (negated or not)
  * An empty list matches nothing, so its negation matches everything
  */
-function generateOneOf(
-	node: OneOfExpression,
-	state: GeneratorState,
-): FilterPredicate<Record<string, unknown>> {
+function generateOneOf(node: OneOfExpression, state: GeneratorState): FilterPredicate {
 	const field = resolveField(node.field, state);
 	return generateMembership(field, node.values, state, node.negated, node.negated);
 }
@@ -552,10 +534,7 @@ function generateOneOf(
 /**
  * Generates predicate for exists expression (negated or not)
  */
-function generateExists(
-	node: ExistsExpression,
-	state: GeneratorState,
-): FilterPredicate<Record<string, unknown>> {
+function generateExists(node: ExistsExpression, state: GeneratorState): FilterPredicate {
 	const field = resolveField(node.field, state);
 	const accessor = state.fieldAccessor;
 	if (node.negated) {
@@ -588,7 +567,7 @@ function generateExists(
 function generateBooleanField(
 	node: BooleanFieldExpression,
 	state: GeneratorState,
-): FilterPredicate<Record<string, unknown>> {
+): FilterPredicate {
 	const field = resolveField(node.field, state);
 	const accessor = state.fieldAccessor;
 	if (accessor) {
@@ -608,7 +587,7 @@ function generateRangeComparison(
 	min: number,
 	max: number,
 	state: GeneratorState,
-): FilterPredicate<Record<string, unknown>> {
+): FilterPredicate {
 	const accessor = state.fieldAccessor;
 	if (operator === "!=") {
 		if (accessor) {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,7 +4,7 @@
 		"target": "ES2022",
 		"module": "ESNext",
 		"moduleResolution": "bundler",
-		"lib": ["ES2022"],
+		"lib": ["ES2023"],
 		"strict": true,
 		"skipLibCheck": true,
 		"declaration": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,10 @@
 {
 	"extends": "./tsconfig.base.json",
 	"compilerOptions": {
+		"lib": ["ES2023", "DOM", "DOM.Iterable"],
 		"types": ["@types/bun"],
+		"allowImportingTsExtensions": true,
 		"noEmit": true
 	},
-	"include": ["scripts/*.ts"]
+	"exclude": ["**/dist", "**/node_modules"]
 }

--- a/website/lib/llms.ts
+++ b/website/lib/llms.ts
@@ -175,13 +175,13 @@ export async function copyLlmsDocs(): Promise<void> {
 
 	const packages = await readdir("../packages");
 	await Promise.all(
-		packages.map(async (pkg) => {
-			const readmeFile = file(`../packages/${pkg}/README.md`);
+		packages.map(async (pkgName) => {
+			const readmeFile = file(`../packages/${pkgName}/README.md`);
 			if (await readmeFile.exists()) {
-				await mkdir(`dist/llms/packages/${pkg}`, { recursive: true });
+				await mkdir(`dist/llms/packages/${pkgName}`, { recursive: true });
 				const content = await readmeFile.text();
 				const formatted = await format("README.md", content);
-				await write(`dist/llms/packages/${pkg}/README.txt`, formatted.code);
+				await write(`dist/llms/packages/${pkgName}/README.txt`, formatted.code);
 			}
 		}),
 	);

--- a/website/lib/llms.ts
+++ b/website/lib/llms.ts
@@ -44,7 +44,7 @@ async function extractExamples(): Promise<ExampleInfo[]> {
 	const exampleDirs = await readdir("../examples");
 
 	const results = await Promise.all(
-		exampleDirs.sort().map(async (dir) => {
+		exampleDirs.toSorted().map(async (dir) => {
 			const readmeFile = file(`../examples/${dir}/README.md`);
 			if (!(await readmeFile.exists())) return null;
 

--- a/website/lib/markdown.ts
+++ b/website/lib/markdown.ts
@@ -268,6 +268,8 @@ export function extractSubsection(content: string, subsectionName: string): stri
 	return collected.join("").trim();
 }
 
+const formatRow = (cells: string[]) => `| ${cells.join(" | ")} |`;
+
 export function extractTable(content: string): string | null {
 	const rows: string[][] = [];
 	let currentRow: string[] = [];
@@ -303,8 +305,6 @@ export function extractTable(content: string): string | null {
 	const header = rows[0];
 	const separator = header.map(() => "---");
 	const dataRows = rows.slice(1);
-
-	const formatRow = (cells: string[]) => `| ${cells.join(" | ")} |`;
 
 	const tableLines = [formatRow(header), formatRow(separator), ...dataRows.map(formatRow)];
 
@@ -342,7 +342,7 @@ export async function findDocs(): Promise<{ required: DocFile[]; optional: DocFi
 
 	const packages = await readdir(`${ROOT}/packages`);
 	const pkgDocs = await Promise.all(
-		packages.sort().map(async (pkgName) => {
+		packages.toSorted().map(async (pkgName) => {
 			const readmeFile = file(`${ROOT}/packages/${pkgName}/README.md`);
 			if (await readmeFile.exists()) {
 				const content = await readmeFile.text();
@@ -376,7 +376,7 @@ export async function findDocs(): Promise<{ required: DocFile[]; optional: DocFi
 	try {
 		const examples = await readdir(`${ROOT}/examples`);
 		const exampleDocs = await Promise.all(
-			examples.sort().map(async (example) => {
+			examples.toSorted().map(async (example) => {
 				const readmeFile = file(`${ROOT}/examples/${example}/README.md`);
 				if (await readmeFile.exists()) {
 					const content = await readmeFile.text();

--- a/website/lib/markdown.ts
+++ b/website/lib/markdown.ts
@@ -342,16 +342,16 @@ export async function findDocs(): Promise<{ required: DocFile[]; optional: DocFi
 
 	const packages = await readdir(`${ROOT}/packages`);
 	const pkgDocs = await Promise.all(
-		packages.sort().map(async (pkg) => {
-			const readmeFile = file(`${ROOT}/packages/${pkg}/README.md`);
+		packages.sort().map(async (pkgName) => {
+			const readmeFile = file(`${ROOT}/packages/${pkgName}/README.md`);
 			if (await readmeFile.exists()) {
 				const content = await readmeFile.text();
 				return {
-					name: `@filtron/${pkg}`,
-					path: `packages/${pkg}/README.txt`,
-					url: `${BASE_URL}/llms/packages/${pkg}/README.txt`,
+					name: `@filtron/${pkgName}`,
+					path: `packages/${pkgName}/README.txt`,
+					url: `${BASE_URL}/llms/packages/${pkgName}/README.txt`,
 					description: extractDescription(content),
-					isOptional: pkg === "benchmark",
+					isOptional: pkgName === "benchmark",
 				};
 			}
 			return null;

--- a/website/package.json
+++ b/website/package.json
@@ -13,6 +13,7 @@
 	},
 	"devDependencies": {
 		"@iconscout/unicons": "4.2.0",
+		"@types/bun": "catalog:",
 		"shiki": "4.3.1",
 		"wrangler": "4.110.0"
 	},

--- a/website/src/grid.ts
+++ b/website/src/grid.ts
@@ -15,6 +15,9 @@ export interface Particle {
 	targetAlpha: number;
 }
 
+// Random distribution - different each visit
+const random = (): number => Math.random();
+
 const SHAPES: readonly Shape[] = ["circle", "triangle", "square"];
 const COLORS: readonly Color[] = ["red", "blue", "green", "orange", "purple"];
 
@@ -128,9 +131,6 @@ export class ParticleGrid {
 		// Calculate particle count based on area, aiming for ~40px average spacing
 		const area = this.lastWidth * this.initialHeight;
 		const targetCount = Math.floor(area / (this.gridSpacing * this.gridSpacing));
-
-		// Random distribution - different each visit
-		const random = (): number => Math.random();
 
 		// Minimum distance between particle centers
 		const minDistance = 20;

--- a/website/src/highlight.ts
+++ b/website/src/highlight.ts
@@ -46,6 +46,7 @@ function tokenTypeToClass(type: TokenType): HighlightClass | null {
 			return "punctuation";
 		case "DOT":
 		case "EOF":
+		default:
 			return null;
 	}
 }

--- a/website/src/main.ts
+++ b/website/src/main.ts
@@ -18,7 +18,7 @@ function randomItem<T>(arr: readonly T[]): T {
 }
 
 function pickMultiple<T>(arr: readonly T[], count: number): T[] {
-	const shuffled = [...arr].sort(() => Math.random() - 0.5);
+	const shuffled = arr.toSorted(() => Math.random() - 0.5);
 	return shuffled.slice(0, count);
 }
 


### PR DESCRIPTION
### Why

A review bot caught an unused type import that the lint stack structurally could not: oxlint's default profile only enables the `correctness` category, the type-aware pass runs type-checked rules rather than hygiene rules and `tsconfig.base.json` excludes test files so tsc never sees them.

### What

1. Enable the suspicious category with two opt-outs
2. Add additional rules that I learned from in #311 

Refs: #311 