### PR TITLE
feat(core): add a canonical query printer

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -164,6 +164,17 @@ walk(ast, (node) => {
 // fields: ["age", "status"]
 ```
 
+### `print(node: ASTNode): string`
+
+Prints an AST as canonical Filtron query text. Parsing the output reproduces the AST, so `print` is suitable for canonicalizing queries (cache keys, logs) and roundtrip testing. Parentheses appear only where a child binds looser than its parent.
+
+```typescript
+import { parseOrThrow, print } from "@filtron/core";
+
+print(parseOrThrow("(a AND (b OR c))"));
+// "a AND (b OR c)"
+```
+
 ### `validateFields(node: ASTNode, allowedFields: readonly string[]): void`
 
 Validates that every field referenced in an AST is in the allowlist. Throws an `Error` on the first disallowed field. Consumers like @filtron/js and @filtron/sql use this for their `allowedFields` option.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,9 @@ export type { ParseOptions, ParseResult, ParseSuccess, ParseFailure } from "./pa
 // AST walker
 export { walk } from "./walker";
 
+// Canonical printing
+export { print } from "./printer";
+
 // AST field validation
 export { validateFields } from "./validate";
 

--- a/packages/core/src/printer.test.ts
+++ b/packages/core/src/printer.test.ts
@@ -90,5 +90,13 @@ describe("print()", () => {
 				value: { type: "bogus" },
 			} as never),
 		).toThrow("Unknown value type");
+		expect(() =>
+			print({
+				type: "comparison",
+				field: "a",
+				operator: "=",
+				value: { type: "range", kind: "temporal", min: { type: "bogus" }, max: { type: "now" } },
+			} as never),
+		).toThrow("Unknown temporal point type");
 	});
 });

--- a/packages/core/src/printer.test.ts
+++ b/packages/core/src/printer.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import { parseOrThrow } from "./parser";
+import { print } from "./printer";
+
+/**
+ * Queries covering every node type, value kind and precedence shape.
+ * Each must survive parse -> print -> parse with a deeply equal AST.
+ */
+const roundtripQueries = [
+	"verified",
+	"email?",
+	"-email",
+	"-user.email",
+	"NOT suspended",
+	"age > 18",
+	"age >= 18",
+	"age < 65",
+	"age <= 65",
+	"age = 25",
+	"age != 25",
+	"age : 18",
+	'status = "active"',
+	'name ~ "john"',
+	'name = "line\\nbreak\\ttab\\r\\\\slash\\"quote"',
+	"status = active",
+	"user.profile.age >= 18",
+	"verified = true",
+	"premium = false",
+	"score = -1.5",
+	"age = 18..65",
+	"age != 18..65",
+	"score : 0.5..9.75",
+	"temperature = -10..30",
+	'status : ["pending", "approved"]',
+	"role !: [admin, moderator]",
+	"priority : [1, 2, 3]",
+	'field : [1, "two", true]',
+	"created > @2024-06-01",
+	"created <= @2024-06-30T14:30:00Z",
+	"created = @2024-06-01T08:00:00.500+02:00",
+	"updated > @now",
+	"updated > @now-7d",
+	"scheduled < @now+2h",
+	"deployed = @2024-06-01..2024-06-30",
+	"created = @now-7d..now",
+	"released != @2024-06-01T00:00:00Z..now-1d",
+	"a AND b",
+	"a OR b",
+	"a AND b AND c",
+	"a OR b OR c AND d",
+	"(a OR b) AND c",
+	"NOT (a OR b)",
+	"NOT (a AND b) OR c",
+	"a AND NOT b",
+	"NOT a AND NOT b",
+	'(role = "admin" OR role = "moderator") AND status = "active" AND age >= 18',
+	"email? AND -deleted AND status : [active] AND age = 18..65 AND created > @now-1w",
+];
+
+describe("print()", () => {
+	test.each(roundtripQueries)("roundtrips %s", (query) => {
+		const ast = parseOrThrow(query);
+		const printed = print(ast);
+		expect(parseOrThrow(printed)).toEqual(ast);
+	});
+
+	test("prints canonically", () => {
+		expect(print(parseOrThrow("(a AND (b OR c))"))).toBe("a AND (b OR c)");
+		expect(print(parseOrThrow("((a)) AND (b AND c)"))).toBe("a AND b AND c");
+		expect(print(parseOrThrow("a OR (b AND c)"))).toBe("a OR b AND c");
+		expect(print(parseOrThrow('status="active"AND age>18'))).toBe('status = "active" AND age > 18');
+		expect(print(parseOrThrow("email EXISTS"))).toBe("email?");
+		expect(print(parseOrThrow("NOT NOT a"))).toBe("NOT NOT a");
+	});
+
+	test("canonical output is a fixed point", () => {
+		for (const query of roundtripQueries) {
+			const printed = print(parseOrThrow(query));
+			expect(print(parseOrThrow(printed))).toBe(printed);
+		}
+	});
+
+	test("throws on unknown node and value types", () => {
+		expect(() => print({ type: "bogus" } as never)).toThrow("Unknown node type");
+		expect(() =>
+			print({
+				type: "comparison",
+				field: "a",
+				operator: "=",
+				value: { type: "bogus" },
+			} as never),
+		).toThrow("Unknown value type");
+	});
+});

--- a/packages/core/src/printer.ts
+++ b/packages/core/src/printer.ts
@@ -109,14 +109,22 @@ function printValue(value: Value): string {
  * Prints a temporal point without its sigil
  */
 function printTemporalPoint(point: TemporalPoint): string {
-	if (point.type === "date") {
-		return point.value;
+	switch (point.type) {
+		case "date":
+			return point.value;
+		case "now": {
+			if (point.offset === null) {
+				return "now";
+			}
+			const { amount, unit } = point.offset;
+			return amount < 0 ? `now-${-amount}${unit}` : `now+${amount}${unit}`;
+		}
+		default: {
+			// TypeScript exhaustiveness check
+			const _exhaustive: never = point;
+			throw new Error(`Unknown temporal point type: ${(point as TemporalPoint).type}`);
+		}
 	}
-	if (point.offset === null) {
-		return "now";
-	}
-	const { amount, unit } = point.offset;
-	return amount < 0 ? `now-${-amount}${unit}` : `now+${amount}${unit}`;
 }
 
 /**

--- a/packages/core/src/printer.ts
+++ b/packages/core/src/printer.ts
@@ -1,0 +1,150 @@
+/**
+ * Canonical printer for Filtron ASTs
+ */
+
+import type { ASTNode, TemporalPoint, Value } from "./types";
+
+/**
+ * Language precedence (lowest to highest): OR < AND < NOT < primary.
+ * A child wraps in parentheses only when it binds looser than its parent.
+ */
+const PREC_OR = 1;
+const PREC_AND = 2;
+const PREC_NOT = 3;
+
+/**
+ * Prints an AST as canonical Filtron query text
+ *
+ * Parsing the output reproduces the AST: parseOrThrow(print(ast))
+ * is deeply equal to ast for any parser-produced tree. Parentheses
+ * appear only where a child binds looser than its parent, strings are
+ * double-quoted with escapes, and temporal values print behind @.
+ * Useful for canonicalizing queries (cache keys, logs) and roundtrip
+ * testing.
+ *
+ * @param node - The AST node to print
+ * @returns The canonical query text
+ *
+ * @example
+ * ```typescript
+ * import { parseOrThrow, print } from "@filtron/core";
+ *
+ * print(parseOrThrow("(a AND (b OR c))"));
+ * // "a AND (b OR c)"
+ * ```
+ */
+export function print(node: ASTNode): string {
+	return printNode(node, 0);
+}
+
+/**
+ * Recursively prints a node under the given parent precedence
+ */
+function printNode(node: ASTNode, parentPrec: number): string {
+	switch (node.type) {
+		case "or": {
+			let text = printNode(node.children[0], PREC_OR);
+			for (let i = 1; i < node.children.length; i++) {
+				text += " OR " + printNode(node.children[i], PREC_OR);
+			}
+			return parentPrec > PREC_OR ? `(${text})` : text;
+		}
+		case "and": {
+			let text = printNode(node.children[0], PREC_AND);
+			for (let i = 1; i < node.children.length; i++) {
+				text += " AND " + printNode(node.children[i], PREC_AND);
+			}
+			return parentPrec > PREC_AND ? `(${text})` : text;
+		}
+		case "not":
+			return `NOT ${printNode(node.expression, PREC_NOT)}`;
+		case "comparison":
+			return `${node.field} ${node.operator} ${printValue(node.value)}`;
+		case "oneOf": {
+			const values = node.values.map(printValue).join(", ");
+			return `${node.field} ${node.negated ? "!:" : ":"} [${values}]`;
+		}
+		case "exists":
+			return node.negated ? `-${node.field}` : `${node.field}?`;
+		case "booleanField":
+			return node.field;
+		default: {
+			// TypeScript exhaustiveness check
+			const _exhaustive: never = node;
+			throw new Error(`Unknown node type: ${(node as ASTNode).type}`);
+		}
+	}
+}
+
+/**
+ * Prints a value in comparison or membership position
+ */
+function printValue(value: Value): string {
+	switch (value.type) {
+		case "string":
+			return `"${escapeString(value.value)}"`;
+		case "number":
+			return String(value.value);
+		case "boolean":
+			return value.value ? "true" : "false";
+		case "identifier":
+			return value.value;
+		case "range":
+			if (value.kind === "temporal") {
+				return `@${printTemporalPoint(value.min)}..${printTemporalPoint(value.max)}`;
+			}
+			return `${value.min}..${value.max}`;
+		case "date":
+		case "now":
+			return `@${printTemporalPoint(value)}`;
+		default: {
+			// TypeScript exhaustiveness check
+			const _exhaustive: never = value;
+			throw new Error(`Unknown value type: ${(value as Value).type}`);
+		}
+	}
+}
+
+/**
+ * Prints a temporal point without its sigil
+ */
+function printTemporalPoint(point: TemporalPoint): string {
+	if (point.type === "date") {
+		return point.value;
+	}
+	if (point.offset === null) {
+		return "now";
+	}
+	const { amount, unit } = point.offset;
+	return amount < 0 ? `now-${-amount}${unit}` : `now+${amount}${unit}`;
+}
+
+/**
+ * Escapes a string literal for double-quoted output, reversing the
+ * lexer's escape handling
+ */
+function escapeString(value: string): string {
+	let result = "";
+	for (const char of value) {
+		switch (char) {
+			case "\\":
+				result += "\\\\";
+				break;
+			case '"':
+				result += '\\"';
+				break;
+			case "\n":
+				result += "\\n";
+				break;
+			case "\t":
+				result += "\\t";
+				break;
+			case "\r":
+				result += "\\r";
+				break;
+			default:
+				result += char;
+		}
+	}
+	return result;
+}


### PR DESCRIPTION
### Why

A printer enables canonicalization (stable cache keys for parsed queries, readable logs) and parse/print/parse roundtrip testing, complementing the precedence-aware SQL printer from

### What

- `print(ast): string` in @filtron/core, exported alongside `walk`/`validateFields` (tree-shakeable for parse-only consumers).
- Canonical choices: parentheses only where a child binds looser than its parent (`(a AND (b OR c))` prints as `a AND (b OR c)`); strings double-quoted with the lexer's escape set reversed; `exists` prints `field?`, negated exists `-field`, `EXISTS` keyword normalizes to `?`; temporal values print behind a single `@` including range bounds.
- Two properties pinned in tests over a corpus covering every node type, value kind, and precedence shape: `parseOrThrow(print(ast))` deep-equals the AST, and printed output is a fixed point (printing it again is identity).

Closes: #292
Refs: #264