### PR TITLE
feat(sql): add dialect presets

### DIFF
--- a/packages/sql/README.md
+++ b/packages/sql/README.md
@@ -46,14 +46,17 @@ interface SQLResult {
 
 #### Options
 
-| Option           | Type                          | Default      | Description                                   |
-| ---------------- | ----------------------------- | ------------ | --------------------------------------------- |
-| `parameterStyle` | `"numbered"` \| `"question"`  | `"numbered"` | Placeholder format                            |
-| `fieldMapper`    | `(field: string) => string`   | `undefined`  | Transform field names to column names         |
-| `valueMapper`    | `(value: unknown) => unknown` | `undefined`  | Custom transform for `~` values (see below)   |
-| `likeMode`       | `"contains"` \| `"raw"`       | `"contains"` | How `~` builds its LIKE parameter (see below) |
-| `startIndex`     | `number`                      | `1`          | Starting index for numbered placeholders      |
-| `allowedFields`  | `string[]`                    | `undefined`  | Allowlist of field names (throws otherwise)   |
+| Option           | Type                                    | Default      | Description                                   |
+| ---------------- | --------------------------------------- | ------------ | --------------------------------------------- |
+| `dialect`        | `"postgres"` \| `"mysql"` \| `"sqlite"` | `undefined`  | Preset for dialect-specific defaults          |
+| `parameterStyle` | `"numbered"` \| `"question"`            | `"numbered"` | Placeholder format                            |
+| `fieldMapper`    | `(field: string) => string`             | `undefined`  | Transform field names to column names         |
+| `valueMapper`    | `(value: unknown) => unknown`           | `undefined`  | Custom transform for `~` values (see below)   |
+| `likeMode`       | `"contains"` \| `"raw"`                 | `"contains"` | How `~` builds its LIKE parameter (see below) |
+| `startIndex`     | `number`                                | `1`          | Starting index for numbered placeholders      |
+| `allowedFields`  | `string[]`                              | `undefined`  | Allowlist of field names (throws otherwise)   |
+
+A `dialect` sets the parameter style (`postgres` uses `numbered`; `mysql` and `sqlite` use `question`); explicitly supplied options override the preset.
 
 #### Parameter styles
 

--- a/packages/sql/src/converter.test.ts
+++ b/packages/sql/src/converter.test.ts
@@ -717,6 +717,18 @@ describe("SQL", () => {
 			expect(result.params).toEqual([18]);
 		});
 
+		test("unknown dialect throws instead of silently defaulting", () => {
+			const ast: ASTNode = {
+				type: "comparison",
+				field: "age",
+				operator: ">",
+				value: { type: "number", value: 18 },
+			};
+
+			expect(() => toSQL(ast, { dialect: "oracle" as never })).toThrow("Unknown dialect: oracle");
+			expect(() => toSQL(ast, { dialect: null as never })).toThrow("Unknown dialect: null");
+		});
+
 		test("sqlite uses question mark parameters", () => {
 			const result = toSQL(ast, { dialect: "sqlite" });
 			expect(result.sql).toBe("age > ?");

--- a/packages/sql/src/converter.test.ts
+++ b/packages/sql/src/converter.test.ts
@@ -718,13 +718,6 @@ describe("SQL", () => {
 		});
 
 		test("unknown dialect throws instead of silently defaulting", () => {
-			const ast: ASTNode = {
-				type: "comparison",
-				field: "age",
-				operator: ">",
-				value: { type: "number", value: 18 },
-			};
-
 			expect(() => toSQL(ast, { dialect: "oracle" as never })).toThrow("Unknown dialect: oracle");
 			expect(() => toSQL(ast, { dialect: null as never })).toThrow("Unknown dialect: null");
 		});

--- a/packages/sql/src/converter.test.ts
+++ b/packages/sql/src/converter.test.ts
@@ -697,6 +697,45 @@ describe("SQL", () => {
 		});
 	});
 
+	describe("Dialect Presets", () => {
+		const ast: ASTNode = {
+			type: "comparison",
+			field: "age",
+			operator: ">",
+			value: { type: "number", value: 18 },
+		};
+
+		test("postgres uses numbered parameters", () => {
+			const result = toSQL(ast, { dialect: "postgres" });
+			expect(result.sql).toBe("age > $1");
+			expect(result.params).toEqual([18]);
+		});
+
+		test("mysql uses question mark parameters", () => {
+			const result = toSQL(ast, { dialect: "mysql" });
+			expect(result.sql).toBe("age > ?");
+			expect(result.params).toEqual([18]);
+		});
+
+		test("sqlite uses question mark parameters", () => {
+			const result = toSQL(ast, { dialect: "sqlite" });
+			expect(result.sql).toBe("age > ?");
+			expect(result.params).toEqual([18]);
+		});
+
+		test("explicit parameterStyle overrides the dialect preset", () => {
+			const result = toSQL(ast, { dialect: "mysql", parameterStyle: "numbered" });
+			expect(result.sql).toBe("age > $1");
+			expect(result.params).toEqual([18]);
+		});
+
+		test("no dialect keeps the numbered default", () => {
+			const result = toSQL(ast, {});
+			expect(result.sql).toBe("age > $1");
+			expect(result.params).toEqual([18]);
+		});
+	});
+
 	describe("Field Mapping", () => {
 		test("custom field mapper", () => {
 			const ast: ASTNode = {

--- a/packages/sql/src/converter.ts
+++ b/packages/sql/src/converter.ts
@@ -166,9 +166,12 @@ export function toSQL(ast: ASTNode, options: SQLOptions = {}): SQLResult {
 	}
 
 	// Explicit parameterStyle wins, then the dialect preset, then 'numbered'
-	const parameterStyle =
-		options.parameterStyle ??
-		(options.dialect === undefined ? undefined : DIALECT_PRESETS[options.dialect].parameterStyle);
+	const preset = options.dialect === undefined ? undefined : DIALECT_PRESETS[options.dialect];
+	if (options.dialect !== undefined && preset === undefined) {
+		// Guards untyped callers: a typo must not silently fall back
+		throw new Error(`Unknown dialect: ${String(options.dialect)}`);
+	}
+	const parameterStyle = options.parameterStyle ?? preset?.parameterStyle;
 
 	const state: GeneratorState = {
 		params: [],

--- a/packages/sql/src/converter.ts
+++ b/packages/sql/src/converter.ts
@@ -169,7 +169,7 @@ export function toSQL(ast: ASTNode, options: SQLOptions = {}): SQLResult {
 	const preset = options.dialect === undefined ? undefined : DIALECT_PRESETS[options.dialect];
 	if (options.dialect !== undefined && preset === undefined) {
 		// Guards untyped callers: a typo must not silently fall back
-		throw new Error(`Unknown dialect: ${String(options.dialect)}`);
+		throw new Error(`Unknown dialect: ${options.dialect}`);
 	}
 	const parameterStyle = options.parameterStyle ?? preset?.parameterStyle;
 

--- a/packages/sql/src/converter.ts
+++ b/packages/sql/src/converter.ts
@@ -32,6 +32,17 @@ export interface SQLResult {
  */
 export interface SQLOptions {
 	/**
+	 * Dialect preset that sets defaults for other options
+	 * - 'postgres': parameterStyle 'numbered'
+	 * - 'mysql': parameterStyle 'question'
+	 * - 'sqlite': parameterStyle 'question'
+	 *
+	 * Explicitly supplied options always override the preset.
+	 * @default undefined
+	 */
+	dialect?: "postgres" | "mysql" | "sqlite";
+
+	/**
 	 * Parameter placeholder style
 	 * - 'numbered': PostgreSQL/CockroachDB style ($1, $2, $3)
 	 * - 'question': MySQL/SQLite/DuckDB style (?, ?, ?)
@@ -116,6 +127,20 @@ const identityValue = (value: string | number | boolean): string | number | bool
 const NUMBERED_PLACEHOLDERS: string[] = Array.from({ length: 65 }, (_, i) => `$${i}`);
 
 /**
+ * Per-dialect option defaults, consulted only when the corresponding option
+ * is not supplied explicitly. Future dialect-specific defaults (identifier
+ * quoting, LIKE escape clauses) slot in here without API changes.
+ */
+const DIALECT_PRESETS: Record<
+	NonNullable<SQLOptions["dialect"]>,
+	{ parameterStyle: NonNullable<SQLOptions["parameterStyle"]> }
+> = {
+	postgres: { parameterStyle: "numbered" },
+	mysql: { parameterStyle: "question" },
+	sqlite: { parameterStyle: "question" },
+};
+
+/**
  * Converts a Filtron AST to a parameterized SQL WHERE clause
  *
  * @param ast - The Filtron AST node to convert
@@ -140,9 +165,14 @@ export function toSQL(ast: ASTNode, options: SQLOptions = {}): SQLResult {
 		validateFields(ast, options.allowedFields);
 	}
 
+	// Explicit parameterStyle wins, then the dialect preset, then 'numbered'
+	const parameterStyle =
+		options.parameterStyle ??
+		(options.dialect === undefined ? undefined : DIALECT_PRESETS[options.dialect].parameterStyle);
+
 	const state: GeneratorState = {
 		params: [],
-		numbered: options.parameterStyle !== "question",
+		numbered: parameterStyle !== "question",
 		fieldMapper: options.fieldMapper ?? identityField,
 		likeValue: options.valueMapper ?? (options.likeMode === "raw" ? identityValue : contains),
 		paramIndex: options.startIndex ?? 1,


### PR DESCRIPTION
### Why

Parameter style (and identifier quotin, LIKE escape clauses) are per-database decisions configured on the fly which is easy to misconfigure.

### What

- `dialect?: "postgres" | "mysql" | "sqlite"` on SQLOptions: postgres presets `numbered` parameters, mysql/sqlite preset `question`. Explicit options always override the preset; no dialect keeps behavior byte-identical.
- A module-level preset table (zero per-call allocation, never consulted when dialect is unset) whose JSDoc marks where future per-dialect defaults slot in without API changes.
- Tests for each dialect, the override precedence, and the unset default; README options table updated.

### Notes

- Implemented by a Claude Code agent (Claude Fable 5), reviewed and rebased over the temporal merge before pushing

Closes: #290 