### PR TITLE
docs: state the tab indentation convention explicitly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ via `--type-aware --type-check` flags in the lint command.
 - No `any` types
 - No classes—use functions (except Lexer/Parser which use classes for state)
 - Prefer `switch` with exhaustiveness checks over `if/else` chains
+- Indentation is tabs, enforced by oxfmt; never convert to spaces
 
 ## Parser architecture
 


### PR DESCRIPTION
### Why

oxfmt enforces tab indentation, but no written guideline says so. CodeRabbit infers coding guidelines from documentation and has proposed tabs-to-2-space conversions on four consecutive pull requests (#306, #307, #311, #314) — each skipped manually since the conversion would fail `bun run lint`.

### What

One line in the CLAUDE.md code style section: indentation is tabs, enforced by oxfmt, never convert to spaces.